### PR TITLE
Fixes gh-34, tracker 11086 - add JDBC query timeout configuration

### DIFF
--- a/jasperreports/docs/config.reference.xml
+++ b/jasperreports/docs/config.reference.xml
@@ -554,6 +554,8 @@ storing character or binary values created by the
     <description>
 Property specifying the number of seconds to wait for the <code>Statement</code> created by the 
 <api href="net/sf/jasperreports/engine/query/JRJdbcQueryExecuter.html">JRJdbcQueryExecuter</api> to execute.
+<br/>
+Default value is 0 meaning that there is no limit.
     </description>
   </configProperty>
   

--- a/jasperreports/docs/config.reference.xml
+++ b/jasperreports/docs/config.reference.xml
@@ -547,6 +547,15 @@ storing character or binary values created by the
 <api href="net/sf/jasperreports/engine/query/JRJdbcQueryExecuter.html">JRJdbcQueryExecuter</api>.
     </description>
   </configProperty>
+
+  <!-- net.sf.jasperreports.jdbc.query.timeout -->
+
+  <configProperty name="net.sf.jasperreports.jdbc.query.timeout">
+    <description>
+Property specifying the number of seconds to wait for the <code>Statement</code> created by the 
+<api href="net/sf/jasperreports/engine/query/JRJdbcQueryExecuter.html">JRJdbcQueryExecuter</api> to execute.
+    </description>
+  </configProperty>
   
   <!-- net.sf.jasperreports.query.chunk.token.separators -->
   

--- a/jasperreports/src/jasperreports_messages.properties
+++ b/jasperreports/src/jasperreports_messages.properties
@@ -428,6 +428,7 @@ net.sf.jasperreports.exception.query.parameter.type.selector.clause.required.tok
 net.sf.jasperreports.exception.query.statement.cancel.error=Error canceling SQL statement.
 net.sf.jasperreports.exception.query.statement.execute.error=Error executing SQL statement for: {0}.
 net.sf.jasperreports.exception.query.statement.prepare.error=Error preparing statement for executing the report query:\n\n{0}\n\n
+net.sf.jasperreports.exception.query.statement.timeout.limit.exceeded=Query timeout limit exceeded while executing SQL statement for: {0}.
 net.sf.jasperreports.exception.query.unexpected.multi.parameter.type=Multi parameter value is not array nor collection.
 net.sf.jasperreports.exception.query.unsupported.parameter.type={0} found unsupported query parameter type: {1}.
 net.sf.jasperreports.exception.query.xmla.connection.error=Error loading olap4j driver and getting Connection "{0}".

--- a/jasperreports/src/net/sf/jasperreports/engine/query/JRJdbcQueryExecuter.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/query/JRJdbcQueryExecuter.java
@@ -32,6 +32,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLTimeoutException;
 import java.sql.Types;
 import java.util.Calendar;
 import java.util.Collection;
@@ -71,6 +72,7 @@ public class JRJdbcQueryExecuter extends JRAbstractQueryExecuter
 	public static final String EXCEPTION_MESSAGE_KEY_QUERY_STATEMENT_CANCEL_ERROR = "query.statement.cancel.error";
 	public static final String EXCEPTION_MESSAGE_KEY_QUERY_STATEMENT_EXECUTE_ERROR = "query.statement.execute.error";
 	public static final String EXCEPTION_MESSAGE_KEY_QUERY_STATEMENT_PREPARE_ERROR = "query.statement.prepare.error";
+	public static final String EXCEPTION_MESSAGE_KEY_QUERY_STATEMENT_TIMEOUT_LIMIT_EXCEEDED = "query.statement.timeout.limit.exceeded";
 	public static final String EXCEPTION_MESSAGE_KEY_UNEXPECTED_MULTI_PARAMETER_TYPE = "query.unexpected.multi.parameter.type";
 
 	public static final String CANONICAL_LANGUAGE = "SQL";
@@ -339,6 +341,14 @@ public class JRJdbcQueryExecuter extends JRAbstractQueryExecuter
 				TimeZone reportTimeZone = (TimeZone) getParameterValue(JRParameter.REPORT_TIME_ZONE, true);
 				dataSource.setReportTimeZone(reportTimeZone);
 			}
+			catch (SQLTimeoutException e)
+			{
+				throw
+					new JRException(
+						EXCEPTION_MESSAGE_KEY_QUERY_STATEMENT_TIMEOUT_LIMIT_EXCEEDED,
+						new Object[]{dataset.getName()},
+						e);
+			}
 			catch (SQLException e)
 			{
 				throw 
@@ -449,6 +459,14 @@ public class JRJdbcQueryExecuter extends JRAbstractQueryExecuter
 				if(maxFieldSize != 0)
 				{
 					statement.setMaxFieldSize(maxFieldSize);
+				}
+				
+				int queryTimeoutValue = getPropertiesUtil().getIntegerProperty(dataset,
+						JRJdbcQueryExecuterFactory.PROPERTY_JDBC_QUERY_TIMEOUT,
+						0);
+				if (queryTimeoutValue != 0)
+				{
+					statement.setQueryTimeout(queryTimeoutValue);
 				}
 				
 				Integer reportMaxCount = (Integer) getParameterValue(JRParameter.REPORT_MAX_COUNT);

--- a/jasperreports/src/net/sf/jasperreports/engine/query/JRJdbcQueryExecuterFactory.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/query/JRJdbcQueryExecuterFactory.java
@@ -113,6 +113,17 @@ public class JRJdbcQueryExecuterFactory extends AbstractQueryExecuterFactory imp
 	public static final String PROPERTY_JDBC_MAX_FIELD_SIZE = JRPropertiesUtil.PROPERTY_PREFIX + "jdbc.max.field.size";
 
 	/**
+	 * Property specifying the statement query timeout value (in seconds).
+	 */
+	@Property(
+			category = PropertyConstants.CATEGORY_DATA_SOURCE,
+			scopes = {PropertyScope.CONTEXT, PropertyScope.DATASET},
+			scopeQualifications = {QUERY_EXECUTER_NAME},
+			valueType = Integer.class
+	)
+	public static final String PROPERTY_JDBC_QUERY_TIMEOUT = JRPropertiesUtil.PROPERTY_PREFIX + "jdbc.query.timeout";
+
+	/**
 	 * Flag property specifying if data will be stored in a cached rowset.
 	 */
 	@Property(

--- a/jasperreports/src/net/sf/jasperreports/engine/query/JRJdbcQueryExecuterFactory.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/query/JRJdbcQueryExecuterFactory.java
@@ -117,6 +117,7 @@ public class JRJdbcQueryExecuterFactory extends AbstractQueryExecuterFactory imp
 	 */
 	@Property(
 			category = PropertyConstants.CATEGORY_DATA_SOURCE,
+			defaultValue = "0",
 			scopes = {PropertyScope.CONTEXT, PropertyScope.DATASET},
 			scopeQualifications = {QUERY_EXECUTER_NAME},
 			valueType = Integer.class


### PR DESCRIPTION
Summary: Add the ability to configure the timeout for a JDBC statement query.
https://community.jaspersoft.com/jasperreports-library/issues/11086