### PR TITLE
Fix IllegalArgumentException from Apache POI when exporting blank report

### DIFF
--- a/jasperreports/src/net/sf/jasperreports/engine/export/JRXlsAbstractExporter.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/export/JRXlsAbstractExporter.java
@@ -1432,7 +1432,10 @@ public abstract class JRXlsAbstractExporter<RC extends XlsReportConfiguration, C
 
 		if (configuration.isForcePageBreaks())
 		{
-			addRowBreak(rowCount - skippedRows + startRow - 1);
+			int pageBreakRow = rowCount - skippedRows + startRow - 1;
+			if (pageBreakRow >= 0) {
+				addRowBreak(pageBreakRow);
+			}
 		}
 		
 		if (autoFilterStart != null)


### PR DESCRIPTION
Fix IllegalArgumentException from Apache POI when exporting blank report (no data at all) report as Excel file/

Such behavior is a result of two export options enabled at the same time: forcePageBreaks and removeEmptySpaceBetweenRows

**Example:**
public static void main(String[] args) throws DRException, JRException {
		JasperPrint print = DynamicReports.report().title(text("12345"))
				.columns(column("info", stringType()))
				.setDataSource(new JRBeanCollectionDataSource(asList()))
				.toJasperPrint();
		JRXlsExporter exporter = new JRXlsExporter();
		SimpleXlsReportConfiguration config = new SimpleXlsReportConfiguration();
		**config.setForcePageBreaks(true);
		config.setRemoveEmptySpaceBetweenRows(true);**
		exporter.setConfiguration(config);
		exporter.setExporterInput(new SimpleExporterInput(print));
		exporter.setExporterOutput(new SimpleOutputStreamExporterOutput(new File(System.getProperty("user.dir") + "/test.xls")));
		exporter.exportReport();
	}