### PR TITLE
gh-34 - Allows jdbc query timeout to be set to 0 (meaning no limit)

### DIFF
--- a/jasperreports/docs/config.reference.xml
+++ b/jasperreports/docs/config.reference.xml
@@ -555,7 +555,7 @@ storing character or binary values created by the
 Property specifying the number of seconds to wait for the <code>Statement</code> created by the 
 <api href="net/sf/jasperreports/engine/query/JRJdbcQueryExecuter.html">JRJdbcQueryExecuter</api> to execute.
 <br/>
-Default value is 0 meaning that there is no limit.
+Setting this property to 0 means that there is no limit.
     </description>
   </configProperty>
   

--- a/jasperreports/src/net/sf/jasperreports/engine/query/JRJdbcQueryExecuter.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/query/JRJdbcQueryExecuter.java
@@ -461,10 +461,9 @@ public class JRJdbcQueryExecuter extends JRAbstractQueryExecuter
 					statement.setMaxFieldSize(maxFieldSize);
 				}
 				
-				int queryTimeoutValue = getPropertiesUtil().getIntegerProperty(dataset,
-						JRJdbcQueryExecuterFactory.PROPERTY_JDBC_QUERY_TIMEOUT,
-						0);
-				if (queryTimeoutValue != 0)
+				Integer queryTimeoutValue = getPropertiesUtil().getIntegerProperty(dataset,
+						JRJdbcQueryExecuterFactory.PROPERTY_JDBC_QUERY_TIMEOUT);
+				if (queryTimeoutValue != null && queryTimeoutValue >= 0)
 				{
 					statement.setQueryTimeout(queryTimeoutValue);
 				}

--- a/jasperreports/src/net/sf/jasperreports/engine/query/JRJdbcQueryExecuterFactory.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/query/JRJdbcQueryExecuterFactory.java
@@ -117,7 +117,6 @@ public class JRJdbcQueryExecuterFactory extends AbstractQueryExecuterFactory imp
 	 */
 	@Property(
 			category = PropertyConstants.CATEGORY_DATA_SOURCE,
-			defaultValue = "0",
 			scopes = {PropertyScope.CONTEXT, PropertyScope.DATASET},
 			scopeQualifications = {QUERY_EXECUTER_NAME},
 			valueType = Integer.class


### PR DESCRIPTION
This may be desirable in situations where an application may default all JDBC queries to have
a lower timeout but might want to allow Jasper reports run as long as necessary.