### PR TITLE
Update Apache Commons Collections from v3 to v4

### DIFF
--- a/jasperreports/TIBCO_JasperReportsLibraryCE_LicenseAndNotices.txt
+++ b/jasperreports/TIBCO_JasperReportsLibraryCE_LicenseAndNotices.txt
@@ -455,7 +455,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 *
-Apache Commons Collections - commons-collections:commons-collections:   3.2.2
+Apache Commons Collections - commons-collections:commons-collections4:   4.2
 
 Apache License
 

--- a/jasperreports/demo/samples/openflashchart/src/net/sf/jasperreports/components/ofc/ChartPdfHandler.java
+++ b/jasperreports/demo/samples/openflashchart/src/net/sf/jasperreports/components/ofc/ChartPdfHandler.java
@@ -32,7 +32,7 @@ import net.sf.jasperreports.engine.export.GenericElementPdfHandler;
 import net.sf.jasperreports.engine.export.JRPdfExporterContext;
 import net.sf.jasperreports.repo.RepositoryUtil;
 
-import org.apache.commons.collections.map.ReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 
 import com.lowagie.text.Rectangle;
 import com.lowagie.text.pdf.PdfAnnotation;
@@ -56,9 +56,9 @@ public class ChartPdfHandler implements GenericElementPdfHandler
 
 	public static final String PARAMETER_CHART_DATA = "ChartData";
 
-	private final ReferenceMap existingContexts = new ReferenceMap(ReferenceMap.WEAK, 
-			ReferenceMap.HARD);
-	
+	private final ReferenceMap existingContexts =
+		new ReferenceMap(ReferenceMap.ReferenceStrength.WEAK, ReferenceMap.ReferenceStrength.HARD);
+
 	public boolean toExport(JRGenericPrintElement element)
 	{
 		return true;

--- a/jasperreports/demo/samples/webapp-repo/ivy-lib.xml
+++ b/jasperreports/demo/samples/webapp-repo/ivy-lib.xml
@@ -10,11 +10,10 @@
 		<dependency org="com.lowagie" name="itext" rev="2.1.7.js6" conf="test->*"/>
 		<dependency org="commons-beanutils" name="commons-beanutils" rev="1.9.3" conf="test->*"/>
 		<dependency org="commons-codec" name="commons-codec" rev="1.5" conf="test->*"/>
-		<dependency org="commons-collections" name="commons-collections" rev="3.2.2" conf="test->*"/>
 		<dependency org="commons-digester" name="commons-digester" rev="2.1" conf="test->*"/>
 		<dependency org="commons-lang" name="commons-lang" rev="2.6" conf="test->*"/>
 		<dependency org="commons-logging" name="commons-logging" rev="1.1.1" conf="test->*"/>
-		<dependency org="org.apache.commons" name="commons-collections4" rev="4.1" conf="test->*"/>
+		<dependency org="org.apache.commons" name="commons-collections4" rev="4.2" conf="test->*"/>
 		<dependency org="org.apache.poi" name="poi-ooxml" rev="3.15" conf="test->*"/>
 		<dependency org="org.apache.poi" name="poi" rev="3.15" conf="test->*"/>
 		<dependency org="org.apache.velocity" name="velocity" rev="1.7" conf="test->*"/>

--- a/jasperreports/demo/samples/webapp/ivy-lib.xml
+++ b/jasperreports/demo/samples/webapp/ivy-lib.xml
@@ -9,11 +9,10 @@
 		<dependency org="com.lowagie" name="itext" rev="2.1.7.js6" conf="test->*"/>
 		<dependency org="commons-beanutils" name="commons-beanutils" rev="1.9.3" conf="test->*"/>
 		<dependency org="commons-codec" name="commons-codec" rev="1.5" conf="test->*"/>
-		<dependency org="commons-collections" name="commons-collections" rev="3.2.2" conf="test->*"/>
 		<dependency org="commons-digester" name="commons-digester" rev="2.1" conf="test->*"/>
 		<dependency org="commons-lang" name="commons-lang" rev="2.6" conf="test->*"/>
 		<dependency org="commons-logging" name="commons-logging" rev="1.1.1" conf="test->*"/>
-		<dependency org="org.apache.commons" name="commons-collections4" rev="4.1" conf="test->*"/>
+		<dependency org="org.apache.commons" name="commons-collections4" rev="4.2" conf="test->*"/>
 		<dependency org="org.apache.poi" name="poi-ooxml" rev="3.15" conf="test->*"/>
 		<dependency org="org.apache.poi" name="poi" rev="3.15" conf="test->*"/>
 		<dependency org="org.eclipse.jdt.core.compiler" name="ecj" rev="4.4.2"/>

--- a/jasperreports/ivy.xml
+++ b/jasperreports/ivy.xml
@@ -21,7 +21,6 @@
 		<dependency org="com.lowagie" name="itext" rev="2.1.7.js6"/>
 		<dependency org="commons-beanutils" name="commons-beanutils" rev="1.9.3"/>
 		<dependency org="commons-codec" name="commons-codec" rev="1.5"/>
-		<dependency org="commons-collections" name="commons-collections" rev="3.2.2"/>
 		<dependency org="commons-digester" name="commons-digester" rev="2.1"/>
 		<dependency org="commons-lang" name="commons-lang" rev="2.6" conf="test->*"/>
 		<dependency org="commons-logging" name="commons-logging" rev="1.1.1"/>
@@ -43,7 +42,7 @@
 		<dependency org="net.tascalate.javaflow" name="net.tascalate.javaflow.tools.jar" rev="2.2.1" conf="javaflow->*"/>
 		<dependency org="net.tascalate.javaflow" name="net.tascalate.javaflow.providers.asm5" rev="2.2.1" conf="javaflow->*"/>
 		<dependency org="org.apache.ant" name="ant" rev="1.7.1"/>
-		<dependency org="org.apache.commons" name="commons-collections4" rev="4.1" conf="test->*"/>
+		<dependency org="org.apache.commons" name="commons-collections4" rev="4.2" conf="test->*"/>
 		<dependency org="org.apache.commons" name="commons-pool2" rev="2.4.2"/>
 		<dependency org="org.apache.httpcomponents" name="httpclient" rev="4.3.6"/>
 		<dependency org="org.apache.httpcomponents" name="httpcore" rev="4.3.3"/>

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -208,11 +208,11 @@
 			<version>1.9.3</version>
 			<scope>compile</scope>
 		</dependency>
-		<dependency>
-			<groupId>commons-collections</groupId>
-			<artifactId>commons-collections</artifactId>
-			<version>3.2.2</version>
-			<scope>compile</scope>
+		<dependency>	
+			<groupId>org.apache.commons</groupId>	
+			<artifactId>commons-collections4</artifactId>	
+			<version>4.2</version>	
+			<scope>compile</scope>	
 		</dependency>
 		<dependency>
 			<groupId>commons-digester</groupId>

--- a/jasperreports/src/net/sf/jasperreports/compilers/JavaScriptCompiledEvaluator.java
+++ b/jasperreports/src/net/sf/jasperreports/compilers/JavaScriptCompiledEvaluator.java
@@ -35,7 +35,7 @@ import net.sf.jasperreports.engine.fill.JRFillVariable;
 import net.sf.jasperreports.engine.fill.JasperReportsContextAware;
 import net.sf.jasperreports.functions.FunctionsUtil;
 
-import org.apache.commons.collections.map.ReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.mozilla.javascript.Script;
@@ -51,9 +51,10 @@ public class JavaScriptCompiledEvaluator extends JREvaluator implements JasperRe
 	private static final Log log = LogFactory.getLog(JavaScriptCompiledEvaluator.class);
 
 	protected static final String EXPRESSION_ID_VAR = "_jreid";
-	
-	private static final ReferenceMap scriptClassLoaders = new ReferenceMap(ReferenceMap.HARD, ReferenceMap.SOFT);
-	
+
+	private static final ReferenceMap scriptClassLoaders =
+			new ReferenceMap(ReferenceMap.ReferenceStrength.HARD, ReferenceMap.ReferenceStrength.SOFT);
+
 	protected static JavaScriptClassLoader getScriptClassLoader(String unitName)
 	{
 		JavaScriptClassLoader loader;

--- a/jasperreports/src/net/sf/jasperreports/crosstabs/design/JRDesignCrosstab.java
+++ b/jasperreports/src/net/sf/jasperreports/crosstabs/design/JRDesignCrosstab.java
@@ -39,7 +39,7 @@ import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.TimeZone;
 
-import org.apache.commons.collections.map.LinkedMap;
+import org.apache.commons.collections4.map.LinkedMap;
 
 import net.sf.jasperreports.crosstabs.CrosstabColumnCell;
 import net.sf.jasperreports.crosstabs.CrosstabDeepVisitor;
@@ -1943,7 +1943,7 @@ public class JRDesignCrosstab extends JRDesignElement implements JRCrosstab
 		
 		// this will work as long as SequencedHashMap is part of commons collections
 		// we could also look at PSEUDO_SERIAL_VERSION_UID
-		if (variablesList instanceof org.apache.commons.collections.SequencedHashMap)
+		if (variablesList.getClass().getName().equals("org.apache.commons.collections.SequencedHashMap"))
 		{
 			// converting to the new type
 			variablesList = new LinkedMap(variablesList);

--- a/jasperreports/src/net/sf/jasperreports/crosstabs/fill/calculation/ArbitraryRankComparator.java
+++ b/jasperreports/src/net/sf/jasperreports/crosstabs/fill/calculation/ArbitraryRankComparator.java
@@ -25,7 +25,7 @@ package net.sf.jasperreports.crosstabs.fill.calculation;
 
 import java.util.Comparator;
 
-import org.apache.commons.collections.map.ReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 
 import net.sf.jasperreports.engine.JRRuntimeException;
 
@@ -41,7 +41,8 @@ public class ArbitraryRankComparator implements Comparator<Object>
 	public static final String EXCEPTION_MESSAGE_KEY_RANK_COMPARATOR_OVERFLOW = "crosstabs.calculation.rank.comparator.overflow";
 
 	// using a weak ref map to store ranks per objects
-	private final ReferenceMap ranks = new ReferenceMap(ReferenceMap.WEAK, ReferenceMap.HARD);
+	private final ReferenceMap ranks =
+			new ReferenceMap(ReferenceMap.ReferenceStrength.WEAK, ReferenceMap.ReferenceStrength.HARD);
 	private long rankCounter = Long.MIN_VALUE;
 	
 	@Override

--- a/jasperreports/src/net/sf/jasperreports/crosstabs/fill/calculation/BucketDefinition.java
+++ b/jasperreports/src/net/sf/jasperreports/crosstabs/fill/calculation/BucketDefinition.java
@@ -32,8 +32,8 @@ import net.sf.jasperreports.engine.JRException;
 import net.sf.jasperreports.engine.JRRuntimeException;
 import net.sf.jasperreports.engine.analytics.dataset.BucketOrder;
 
-import org.apache.commons.collections.comparators.ComparableComparator;
-import org.apache.commons.collections.comparators.ReverseComparator;
+import org.apache.commons.collections4.comparators.ComparableComparator;
+import org.apache.commons.collections4.comparators.ReverseComparator;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -123,7 +123,7 @@ public class BucketDefinition
 			if (Comparable.class.isAssignableFrom(valueClass))
 			{
 				// using natural order
-				this.bucketValueComparator = ComparableComparator.getInstance();
+				this.bucketValueComparator = ComparableComparator.INSTANCE;
 			}
 			else
 			{
@@ -164,7 +164,7 @@ public class BucketDefinition
 			{
 				if (comparator == null)
 				{
-					orderComparator = ComparableComparator.getInstance();
+					orderComparator = ComparableComparator.INSTANCE;
 				}
 				else
 				{

--- a/jasperreports/src/net/sf/jasperreports/engine/component/ComponentsEnvironment.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/component/ComponentsEnvironment.java
@@ -29,7 +29,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.collections.map.ReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -52,10 +52,10 @@ public final class ComponentsEnvironment
 	
 	private static final Log log = LogFactory.getLog(ComponentsEnvironment.class);
 	public static final String EXCEPTION_MESSAGE_KEY_BUNDLE_NOT_REGISTERED = "components.bundle.not.registered";
-	
-	private final ReferenceMap cache = new ReferenceMap(
-			ReferenceMap.WEAK, ReferenceMap.HARD);
-	
+
+	private final ReferenceMap cache =
+			new ReferenceMap(ReferenceMap.ReferenceStrength.WEAK, ReferenceMap.ReferenceStrength.HARD);
+
 	private JasperReportsContext jasperReportsContext;
 
 

--- a/jasperreports/src/net/sf/jasperreports/engine/convert/ReportConverter.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/convert/ReportConverter.java
@@ -39,7 +39,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
 
-import org.apache.commons.collections.map.LinkedMap;
+import org.apache.commons.collections4.map.LinkedMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/jasperreports/src/net/sf/jasperreports/engine/data/JRCsvDataSource.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/data/JRCsvDataSource.java
@@ -42,8 +42,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.collections.BidiMap;
-import org.apache.commons.collections.bidimap.DualHashBidiMap;
+import org.apache.commons.collections4.BidiMap;
+import org.apache.commons.collections4.bidimap.DualHashBidiMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/jasperreports/src/net/sf/jasperreports/engine/design/JRAbstractJavaCompiler.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/design/JRAbstractJavaCompiler.java
@@ -32,7 +32,7 @@ import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 
-import org.apache.commons.collections.map.ReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 
 import net.sf.jasperreports.annotations.properties.Property;
 import net.sf.jasperreports.annotations.properties.PropertyScope;
@@ -81,7 +81,9 @@ public abstract class JRAbstractJavaCompiler extends JRAbstractCompiler
 
 
 	private static final Object CLASS_CACHE_NULL_KEY = new Object();
-	private static Map<Object,Map<String,Class<?>>> classCache = new ReferenceMap(ReferenceMap.WEAK, ReferenceMap.SOFT);
+	private static Map<Object,Map<String,Class<?>>> classCache =
+			new ReferenceMap(ReferenceMap.ReferenceStrength.WEAK, ReferenceMap.ReferenceStrength.SOFT);
+
 
 	
 	/**
@@ -154,7 +156,7 @@ public abstract class JRAbstractJavaCompiler extends JRAbstractCompiler
 		Map<String,Class<?>> contextMap = classCache.get(key);
 		if (contextMap == null)
 		{
-			contextMap = new ReferenceMap(ReferenceMap.HARD, ReferenceMap.SOFT);
+			contextMap = new ReferenceMap(ReferenceMap.ReferenceStrength.HARD, ReferenceMap.ReferenceStrength.SOFT);
 			classCache.put(key, contextMap);
 		}
 		contextMap.put(className, loadedClass);

--- a/jasperreports/src/net/sf/jasperreports/engine/export/GenericElementHandlerEnviroment.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/export/GenericElementHandlerEnviroment.java
@@ -28,7 +28,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.collections.map.ReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -55,10 +55,10 @@ public final class GenericElementHandlerEnviroment
 			GenericElementHandlerEnviroment.class);
 	public static final String EXCEPTION_MESSAGE_KEY_HANDLERS_NOT_FOUND_FOR_NAMESPACE = 
 			"export.common.handlers.not.found.for.namespace";
-	
-	private final ReferenceMap handlersCache = new ReferenceMap(
-			ReferenceMap.WEAK, ReferenceMap.HARD);
-	
+
+	private final ReferenceMap handlersCache =
+			new ReferenceMap(ReferenceMap.ReferenceStrength.WEAK, ReferenceMap.ReferenceStrength.HARD);
+
 	private JasperReportsContext jasperReportsContext;
 
 

--- a/jasperreports/src/net/sf/jasperreports/engine/export/JRXlsMetadataExporter.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/export/JRXlsMetadataExporter.java
@@ -54,7 +54,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import org.apache.commons.collections.map.ReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.poi.common.usermodel.HyperlinkType;

--- a/jasperreports/src/net/sf/jasperreports/engine/fill/JRAbstractLRUVirtualizer.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/fill/JRAbstractLRUVirtualizer.java
@@ -41,7 +41,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map.Entry;
 
-import org.apache.commons.collections.map.ReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -252,11 +252,14 @@ public abstract class JRAbstractLRUVirtualizer implements JRVirtualizer
 		this.serializer = serializer;
 		
 		this.pagedIn = new Cache(maxSize);
-		this.pagedOut = new ReferenceMap(ReferenceMap.HARD, ReferenceMap.WEAK);
+		this.pagedOut =
+				new ReferenceMap(ReferenceMap.ReferenceStrength.HARD, ReferenceMap.ReferenceStrength.WEAK);
 		this.lastObjectRef = null;
 
-		this.lastObjectMap = new ReferenceMap(ReferenceMap.WEAK, ReferenceMap.WEAK);
-		this.lastObjectSet = new ReferenceMap(ReferenceMap.WEAK, ReferenceMap.HARD);
+		this.lastObjectMap =
+				new ReferenceMap(ReferenceMap.ReferenceStrength.WEAK, ReferenceMap.ReferenceStrength.WEAK);
+		this.lastObjectSet =
+				new ReferenceMap(ReferenceMap.ReferenceStrength.WEAK, ReferenceMap.ReferenceStrength.HARD);
 	}
 
 	protected synchronized final boolean isPagedOut(String id)

--- a/jasperreports/src/net/sf/jasperreports/engine/fill/JRFillCellContents.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/fill/JRFillCellContents.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.commons.collections.map.ReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 
 import net.sf.jasperreports.crosstabs.JRCellContents;
 import net.sf.jasperreports.crosstabs.fill.JRFillCrosstabObjectFactory;

--- a/jasperreports/src/net/sf/jasperreports/engine/fill/JRFillObjectFactory.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/fill/JRFillObjectFactory.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.collections.map.LinkedMap;
+import org.apache.commons.collections4.map.LinkedMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/jasperreports/src/net/sf/jasperreports/engine/fill/JRIncrementerFactoryCache.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/fill/JRIncrementerFactoryCache.java
@@ -26,7 +26,7 @@ package net.sf.jasperreports.engine.fill;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 
-import org.apache.commons.collections.map.ReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 
 import net.sf.jasperreports.engine.JRRuntimeException;
 
@@ -41,8 +41,8 @@ public final class JRIncrementerFactoryCache
 	/**
 	 *
 	 */
-	private static Map<Class<?>,JRIncrementerFactory> factoriesMap = 
-		new ReferenceMap(ReferenceMap.WEAK, ReferenceMap.HARD);
+	private static Map<Class<?>,JRIncrementerFactory> factoriesMap =
+		new ReferenceMap(ReferenceMap.ReferenceStrength.WEAK, ReferenceMap.ReferenceStrength.HARD);
 
 
 	/**

--- a/jasperreports/src/net/sf/jasperreports/engine/fill/JRVirtualizationContext.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/fill/JRVirtualizationContext.java
@@ -33,7 +33,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.apache.commons.collections.map.ReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -69,8 +69,9 @@ public class JRVirtualizationContext implements Serializable, VirtualizationList
 	public static final String EXCEPTION_MESSAGE_KEY_TEMPLATE_NOT_FOUND_IN_CONTEXT = "fill.virtualizer.template.not.found.in.context";
 	
 	private static final Log log = LogFactory.getLog(JRVirtualizationContext.class);
-	
-	private static final ReferenceMap contexts = new ReferenceMap(ReferenceMap.WEAK, ReferenceMap.WEAK);
+
+	private static final ReferenceMap contexts =
+			new ReferenceMap(ReferenceMap.ReferenceStrength.WEAK, ReferenceMap.ReferenceStrength.WEAK);
 
 	private transient JRVirtualizationContext parentContext;
 	private transient JRVirtualizer virtualizer;

--- a/jasperreports/src/net/sf/jasperreports/engine/fill/StoreFactoryVirtualizer.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/fill/StoreFactoryVirtualizer.java
@@ -29,7 +29,7 @@ import java.util.Iterator;
 import net.sf.jasperreports.engine.JRRuntimeException;
 import net.sf.jasperreports.engine.JRVirtualizable;
 
-import org.apache.commons.collections.map.ReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -50,8 +50,9 @@ public class StoreFactoryVirtualizer extends JRAbstractLRUVirtualizer
 		super(maxSize);
 
 		this.storeFactory = storeFactory;
-		
-		this.contextStores = new ReferenceMap(ReferenceMap.WEAK, ReferenceMap.HARD);
+
+		this.contextStores =
+				new ReferenceMap(ReferenceMap.ReferenceStrength.WEAK, ReferenceMap.ReferenceStrength.HARD);
 	}
 
 	protected VirtualizerStore store(JRVirtualizable o, boolean create)

--- a/jasperreports/src/net/sf/jasperreports/engine/part/PartComponentsEnvironment.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/part/PartComponentsEnvironment.java
@@ -34,7 +34,7 @@ import net.sf.jasperreports.engine.JasperReportsContext;
 import net.sf.jasperreports.engine.component.ComponentKey;
 import net.sf.jasperreports.extensions.ExtensionsEnvironment;
 
-import org.apache.commons.collections.map.ReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -55,8 +55,8 @@ public final class PartComponentsEnvironment
 	public static final String EXCEPTION_MESSAGE_KEY_PART_COMPONENTS_BUNDLE_NOT_REGISTERED = "engine.part.components.bundle.not.registered";
 	
 	private final ReferenceMap cache = new ReferenceMap(
-			ReferenceMap.WEAK, ReferenceMap.HARD);
-	
+			ReferenceMap.ReferenceStrength.WEAK, ReferenceMap.ReferenceStrength.HARD);
+
 	private JasperReportsContext jasperReportsContext;
 
 

--- a/jasperreports/src/net/sf/jasperreports/engine/util/JRSingletonCache.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/util/JRSingletonCache.java
@@ -26,7 +26,7 @@ package net.sf.jasperreports.engine.util;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 
-import org.apache.commons.collections.map.ReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 
 import net.sf.jasperreports.engine.JRException;
 
@@ -53,7 +53,7 @@ public class JRSingletonCache<T>
 	 */
 	public JRSingletonCache(Class<T> itf)
 	{
-		cache = new ReferenceMap(ReferenceMap.WEAK, ReferenceMap.SOFT);
+		cache = new ReferenceMap(ReferenceMap.ReferenceStrength.WEAK, ReferenceMap.ReferenceStrength.SOFT);
 		this.itf = itf;
 	}
 

--- a/jasperreports/src/net/sf/jasperreports/engine/util/xml/JaxenNsAwareXPathExecuter.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/util/xml/JaxenNsAwareXPathExecuter.java
@@ -30,7 +30,7 @@ import java.util.Map;
 
 import net.sf.jasperreports.engine.JRException;
 
-import org.apache.commons.collections.map.ReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 import org.jaxen.JaxenException;
 import org.jaxen.NamespaceContext;
 import org.jaxen.XPath;

--- a/jasperreports/src/net/sf/jasperreports/engine/util/xml/JaxenXPathExecuter.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/util/xml/JaxenXPathExecuter.java
@@ -29,7 +29,7 @@ import java.util.Map;
 
 import net.sf.jasperreports.engine.JRException;
 
-import org.apache.commons.collections.map.ReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 import org.jaxen.JaxenException;
 import org.jaxen.XPath;
 import org.jaxen.dom.DOMXPath;

--- a/jasperreports/src/net/sf/jasperreports/engine/xml/BaseSaxParserFactory.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/xml/BaseSaxParserFactory.java
@@ -32,7 +32,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
-import org.apache.commons.collections.map.ReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.xml.sax.SAXException;
@@ -221,7 +221,7 @@ public abstract class BaseSaxParserFactory implements JRSaxParserFactory
 			ReferenceMap cacheMap = grammarPoolCache.get();
 			if (cacheMap == null)
 			{
-				cacheMap = new ReferenceMap(ReferenceMap.WEAK, ReferenceMap.SOFT);
+				cacheMap = new ReferenceMap(ReferenceMap.ReferenceStrength.WEAK, ReferenceMap.ReferenceStrength.SOFT);
 				grammarPoolCache.set(cacheMap);
 			}
 			

--- a/jasperreports/src/net/sf/jasperreports/engine/xml/JRReportSaxParserFactory.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/xml/JRReportSaxParserFactory.java
@@ -28,7 +28,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.commons.collections.map.ReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/jasperreports/src/net/sf/jasperreports/engine/xml/PrintSaxParserFactory.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/xml/PrintSaxParserFactory.java
@@ -33,7 +33,7 @@ import net.sf.jasperreports.engine.JRPropertiesUtil;
 import net.sf.jasperreports.engine.JasperReportsContext;
 import net.sf.jasperreports.properties.PropertyConstants;
 
-import org.apache.commons.collections.map.ReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/jasperreports/src/net/sf/jasperreports/engine/xml/TemplateSaxParserFactory.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/xml/TemplateSaxParserFactory.java
@@ -26,7 +26,7 @@ package net.sf.jasperreports.engine.xml;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.collections.map.ReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 
 import net.sf.jasperreports.engine.JasperReportsContext;
 

--- a/jasperreports/src/net/sf/jasperreports/engine/xml/XmlValueHandlerUtils.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/xml/XmlValueHandlerUtils.java
@@ -30,7 +30,7 @@ import net.sf.jasperreports.engine.export.JRXmlExporter;
 import net.sf.jasperreports.extensions.ExtensionsEnvironment;
 import net.sf.jasperreports.extensions.ExtensionsRegistry;
 
-import org.apache.commons.collections.map.ReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -60,7 +60,7 @@ public class XmlValueHandlerUtils
 	
 	private XmlValueHandlerUtils()
 	{
-		cache = new ReferenceMap(ReferenceMap.WEAK, ReferenceMap.HARD);
+		cache = new ReferenceMap(ReferenceMap.ReferenceStrength.WEAK, ReferenceMap.ReferenceStrength.HARD);
 	}
 	
 	/**

--- a/jasperreports/src/net/sf/jasperreports/extensions/DefaultExtensionsRegistry.java
+++ b/jasperreports/src/net/sf/jasperreports/extensions/DefaultExtensionsRegistry.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.commons.collections.map.ReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -113,11 +113,11 @@ public class DefaultExtensionsRegistry implements ExtensionsRegistry
 	public static final String PROPERTY_REGISTRY_PREFIX = 
 			JRPropertiesUtil.PROPERTY_PREFIX + "extension.";
 
-	private final ReferenceMap registrySetCache = new ReferenceMap(
-			ReferenceMap.WEAK, ReferenceMap.HARD);
-	
-	private final ReferenceMap registryCache = 
-		new ReferenceMap(ReferenceMap.WEAK, ReferenceMap.HARD);
+	private final ReferenceMap registrySetCache =
+			new ReferenceMap(ReferenceMap.ReferenceStrength.WEAK, ReferenceMap.ReferenceStrength.HARD);
+
+	private final ReferenceMap registryCache =
+		new ReferenceMap(ReferenceMap.ReferenceStrength.WEAK, ReferenceMap.ReferenceStrength.HARD);
 
 	@Override
 	public <T> List<T> getExtensions(Class<T> extensionType)

--- a/jasperreports/src/net/sf/jasperreports/extensions/SpringExtensionsRegistry.java
+++ b/jasperreports/src/net/sf/jasperreports/extensions/SpringExtensionsRegistry.java
@@ -26,7 +26,7 @@ package net.sf.jasperreports.extensions;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.collections.map.ReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
@@ -46,7 +46,7 @@ public class SpringExtensionsRegistry implements ExtensionsRegistry
 	private final ListableBeanFactory beanFactory;
 	
 	private final ReferenceMap extensionBeanNamesCache = new ReferenceMap(
-			ReferenceMap.WEAK, ReferenceMap.HARD);
+			ReferenceMap.ReferenceStrength.WEAK, ReferenceMap.ReferenceStrength.HARD);
 
 	/**
 	 * Creates a Spring-based extension registry.

--- a/jasperreports/src/net/sf/jasperreports/util/CastorUtil.java
+++ b/jasperreports/src/net/sf/jasperreports/util/CastorUtil.java
@@ -51,7 +51,7 @@ import net.sf.jasperreports.engine.util.JRLoader;
 import net.sf.jasperreports.engine.util.VersionComparator;
 import net.sf.jasperreports.engine.xml.JRXmlBaseWriter;
 
-import org.apache.commons.collections.map.ReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.exolab.castor.mapping.Mapping;
@@ -184,7 +184,7 @@ public class CastorUtil
 		{
 			//TODO lucianc prevent double cache creation?
 			xmlContextCache = Collections.synchronizedMap(
-					new ReferenceMap(ReferenceMap.WEAK, ReferenceMap.SOFT));//using soft values is safer
+					new ReferenceMap(ReferenceMap.ReferenceStrength.WEAK, ReferenceMap.ReferenceStrength.SOFT));//using soft values is safer
 			jasperReportsContext.setValue(contextCacheKey, xmlContextCache);
 		}
 		return xmlContextCache;


### PR DESCRIPTION
This is done to allow users depending on JasperReports to get rid of their Collections v3 dependency, which hasn't been maintained for a few years now.

Please let me know if there are further changes necessary (I couldn't get it to build/test because it failed to resolve some of JasperReports' dependency, so any hints are appreciated).