### PR TITLE
Bugfix/gantlabel

### DIFF
--- a/jasperreports/src/net/sf/jasperreports/engine/dtds/jasperreport.dtd
+++ b/jasperreports/src/net/sf/jasperreports/engine/dtds/jasperreport.dtd
@@ -662,10 +662,11 @@
 
 <!ELEMENT ganttChart (chart, ganttDataset, barPlot)>
 <!ELEMENT ganttDataset (dataset?, ganttSeries*)>
-<!ELEMENT ganttSeries (seriesExpression?, taskExpression, subtaskExpression, startDateExpression?, endDateExpression?, percentExpression?)>
+<!ELEMENT ganttSeries (seriesExpression?, taskExpression, subtaskExpression, startDateExpression?, endDateExpression?, percentExpression?, labelExpression?)>
 <!ELEMENT taskExpression (#PCDATA)>
 <!ELEMENT subtaskExpression (#PCDATA)>
 <!ELEMENT percentExpression (#PCDATA)>
+<!ELEMENT labelExpression (#PCDATA)>
 
 <!ELEMENT crosstab (reportElement, crosstabParameter*, parametersMapExpression?, crosstabDataset?, crosstabHeaderCell?, rowGroup*, columnGroup*, measure*, crosstabCell*, whenNoDataCell?)>
 <!ATTLIST crosstab

--- a/jasperreports/src/net/sf/jasperreports/engine/dtds/jasperreport.xsd
+++ b/jasperreports/src/net/sf/jasperreports/engine/dtds/jasperreport.xsd
@@ -7369,6 +7369,7 @@ property.
     <element ref="jr:startDateExpression" minOccurs="0" maxOccurs="1"/>
     <element ref="jr:endDateExpression" minOccurs="0" maxOccurs="1"/>
     <element ref="jr:percentExpression" minOccurs="0" maxOccurs="1"/>
+    <element ref="jr:labelExpression" minOccurs="0" maxOccurs="1"/>
    </sequence>
   </complexType>
  </element>
@@ -7392,6 +7393,14 @@ property.
  <element name="percentExpression">
   <annotation>
    <documentation>Specifies the expression used to determine the percent in a <elem>ganttSeries</elem>.</documentation>
+  </annotation>
+  <complexType mixed="true">
+  </complexType>
+ </element>
+
+ <element name="labelExpression">
+  <annotation>
+   <documentation>Defines a label in a <elem>pieDataset</elem> or <elem>ganttSeries</elem>.</documentation>
   </annotation>
   <complexType mixed="true">
   </complexType>


### PR DESCRIPTION
Added missing labelExpression to xsd and dtd. Fixes org.xml.sax.SAXParseException when loading jrxml

```
 Invalid content was found starting with element 'labelExpression'. No child element is expected at this point.
	at net.sf.jasperreports.engine.xml.JRXmlLoader.loadXML(JRXmlLoader.java:302)
```