### PR TITLE
fix circular tagging in PDF

### DIFF
--- a/jasperreports/src/net/sf/jasperreports/engine/export/JRPdfExporterTagHelper.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/export/JRPdfExporterTagHelper.java
@@ -344,7 +344,7 @@ public class JRPdfExporterTagHelper
 			PdfName pdfNameALL = new PdfName("All");
 			root.mapRole(pdfNameALL, PdfName.SECT);
 			root.mapRole(PdfName.IMAGE, PdfName.FIGURE);
-			root.mapRole(PdfName.TEXT, PdfName.TEXT);
+			root.mapRole(PdfName.TEXT, PdfName.SPAN);
 			allTag = new PdfStructureElement(root, pdfNameALL);
 			if(pdfWriter.getPDFXConformance() == PdfWriter.PDFA1A)
 			{


### PR DESCRIPTION
Mapping TEXT to TEXT creates invalid circular tagging. Mapping TEXT to SPAN solves this problem.