### PR TITLE
add font fallback list feature for PDF output

### DIFF
--- a/jasperreports/src/net/sf/jasperreports/engine/util/JRStyledTextUtil.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/util/JRStyledTextUtil.java
@@ -400,6 +400,8 @@ public class JRStyledTextUtil
 			{
 				codePoint = textChar;
 			}
+			
+			boolean stopSearching = false;
 
 			for (ListIterator<Face> fontIt = validFonts.listIterator(); fontIt.hasNext();)
 			{
@@ -407,8 +409,15 @@ public class JRStyledTextUtil
 				
 				if (!face.supports(codePoint))
 				{
+					if (lastValid != null) {
+						stopSearching = true;
+						break;
+					}
 					fontIt.remove();
 				}
+			}
+			if (stopSearching) {
+				break;
 			}
 			
 			if (validFonts.isEmpty())


### PR DESCRIPTION
problem
https://github.com/neowcng/jr-font-issues

jasperreport report 6.2.2 introduced the font-set feature which help to separate the font usage by script (e.g. Latin -> Arial, Chinese -> Noto Sans CJK TC)
The PR is to extend the feature by testing character-by-character with the actual font supported
