### PR TITLE
Partial FontInfo Cache for ignoreCase=false.

### DIFF
--- a/jasperreports/src/net/sf/jasperreports/engine/fonts/FontInfoKey.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/fonts/FontInfoKey.java
@@ -1,0 +1,68 @@
+package net.sf.jasperreports.engine.fonts;
+
+import java.io.Serializable;
+import java.util.Locale;
+
+/**
+ * Caching key.
+ * 
+ * @author Markus Pscheidt
+ *
+ */
+public class FontInfoKey implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private String name;
+	private Locale locale;
+	
+	public FontInfoKey(String name, Locale locale) {
+		this.name = name;
+		this.locale = locale;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public Locale getLocale() {
+		return locale;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((locale == null) ? 0 : locale.hashCode());
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		FontInfoKey other = (FontInfoKey) obj;
+		if (locale == null) {
+			if (other.locale != null)
+				return false;
+		} else if (!locale.equals(other.locale))
+			return false;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "FontInfoKey [name=" + name + ", locale=" + locale + "]";
+	}
+
+}

--- a/jasperreports/src/net/sf/jasperreports/engine/fonts/FontUtil.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/fonts/FontUtil.java
@@ -60,6 +60,7 @@ public final class FontUtil
 
 	private JasperReportsContext jasperReportsContext;
 
+	private Map<FontInfoKey, FontInfo> fontInfoMap = new HashMap<>();
 
 	/**
 	 *
@@ -174,6 +175,25 @@ public final class FontUtil
 		return attributes;
 	}
 
+	private FontInfo lookupFontInfoCache(String name, boolean ignoreCase, Locale locale) {
+		if (ignoreCase) {
+			// cache not implemented yet for ignoreCase=true
+			return null;
+		}
+		
+		FontInfoKey fontInfoKey = new FontInfoKey(name, locale);
+		return this.fontInfoMap.get(fontInfoKey);
+	}
+
+	private void putIntoFontInfoCache(String name, boolean ignoreCase, Locale locale, FontInfo fontInfo) {
+		if (ignoreCase) {
+			// cache not implemented yet for ignoreCase=true
+			return;
+		}
+
+		FontInfoKey fontInfoKey = new FontInfoKey(name, locale);
+		fontInfoMap.put(fontInfoKey, fontInfo);
+	}
 
 	/**
 	 * Returns font information containing the font family, font face and font style.
@@ -185,9 +205,14 @@ public final class FontUtil
 	 */
 	public FontInfo getFontInfo(String name, boolean ignoreCase, Locale locale)
 	{
-		FontInfo awtFamilyMatchFontInfo = null;
+		// lookup cache entry
+		FontInfo fontInfo = lookupFontInfoCache(name, ignoreCase, locale);
+		if (fontInfo != null) {
+			return fontInfo;
+		}
 
-		//FIXMEFONT do some cache
+		FontInfo awtFamilyMatchFontInfo = null;
+		
 		List<FontFamily> families = jasperReportsContext.getExtensions(FontFamily.class);
 		for (Iterator<FontFamily> itf = families.iterator(); itf.hasNext();)
 		{
@@ -196,7 +221,9 @@ public final class FontUtil
 			{
 				if (equals(name, family.getName(), ignoreCase))
 				{
-					return new FontInfo(family, null, Font.PLAIN);
+					fontInfo = new FontInfo(family, null, Font.PLAIN);
+					putIntoFontInfoCache(name, ignoreCase, locale, fontInfo);
+					return fontInfo;
 				}
 				
 				FontFace face = family.getNormalFace();
@@ -204,7 +231,9 @@ public final class FontUtil
 				{
 					if (equals(name, face.getName(), ignoreCase))
 					{
-						return new FontInfo(family, face, Font.PLAIN);
+						fontInfo = new FontInfo(family, face, Font.PLAIN);
+						putIntoFontInfoCache(name, ignoreCase, locale, fontInfo);
+						return fontInfo;
 					}
 					else if (
 						awtFamilyMatchFontInfo == null
@@ -221,7 +250,9 @@ public final class FontUtil
 				{
 					if (equals(name, face.getName(), ignoreCase))
 					{
-						return new FontInfo(family, face, Font.BOLD);
+						fontInfo = new FontInfo(family, face, Font.BOLD);
+						putIntoFontInfoCache(name, ignoreCase, locale, fontInfo);
+						return fontInfo;
 					}
 					else if (
 						awtFamilyMatchFontInfo == null
@@ -238,7 +269,9 @@ public final class FontUtil
 				{
 					if (equals(name, face.getName(), ignoreCase))
 					{
-						return new FontInfo(family, face, Font.ITALIC);
+						fontInfo = new FontInfo(family, face, Font.ITALIC);
+						putIntoFontInfoCache(name, ignoreCase, locale, fontInfo);
+						return fontInfo;
 					}
 					else if (
 						awtFamilyMatchFontInfo == null
@@ -255,7 +288,9 @@ public final class FontUtil
 				{
 					if (equals(name, face.getName(), ignoreCase))
 					{
-						return new FontInfo(family, face, Font.BOLD | Font.ITALIC);
+						fontInfo = new FontInfo(family, face, Font.BOLD | Font.ITALIC);
+						putIntoFontInfoCache(name, ignoreCase, locale, fontInfo);
+						return fontInfo;
 					}
 					else if (
 						awtFamilyMatchFontInfo == null
@@ -300,6 +335,7 @@ public final class FontUtil
 	 * @return a font info object
 	 * @deprecated Replaced by {@link #getFontInfo(String, boolean, Locale)}.
 	 */
+	@Deprecated
 	public FontInfo getFontInfoIgnoreCase(String name, Locale locale)
 	{
 		return getFontInfo(name, true, locale);
@@ -380,7 +416,6 @@ public final class FontUtil
 	
 	public String getExportFontFamily(String name, Locale locale, String exporterKey)
 	{
-		//FIXMEFONT do some cache
 		FontInfo fontInfo = getFontInfo(name, locale);
 		if (fontInfo != null)
 		{
@@ -451,6 +486,7 @@ public final class FontUtil
 	/**
 	 * @deprecated Replaced by {@link #getAwtFontFromBundles(String, int, float, Locale, boolean)}.
 	 */
+	@Deprecated
 	public Font getAwtFontFromBundles(String name, int style, int size, Locale locale, boolean ignoreMissingFont)
 	{
 		return getAwtFontFromBundles(name, style, (float)size, locale, ignoreMissingFont);


### PR DESCRIPTION
The motivation for this pull request comes from the very long durations needed for exporting Excel files from the JasperViewer, when JasperFonts are installed and when the JVM's Locale was changed from its startup value.

Looking at the JasperReports source code, there are several places with comments suggesting  that performance is not optimal regarding font handling. For example, in net.sf.jasperreports.engine.fonts.FontUtil.getFontInfo(String name, boolean ignoreCase, Locale locale) line 190 there is the comment:
   //FIXMEFONT do some cache

Looking further for the place that causes the delay, java.awt.Font.getFamily() can be identified, which in turn calls sun.font.TrueTypeFont.getFonName(Locale locale). Here, when the given locale (corresponds to Locale.getDefault() in this case) is different from sun.awt.SunToolkit.getStartupLocale(), a rather expensive operation starts to determine the font name. Therefore, avoiding the call to java.awt.Font.getFamily() is desirable.

This pull request includes a simpe cache, which utilizes a map to remember resolved net.sf.jasperreports.engine.fonts.FontInfo objects. The key to the map is defined in the new class FontInfoKey and has currently only two properties, name and local. It only caters for the case when the getFontInfo()'s ignoreCase is false. This flag is false when the method is called from the two-params method getFontInfo(String name, Locale locale), such as when exporting Excel from JasperViewer via JRXlsExporter. For the case when ignoreCase is true, a separate map could be implemented, so that the two cases do not interfere with each other.

The impact of this little cache is rather enormous. In a specific Excel export case, duration without cache was about 1000 seconds, and with cache about 1 second.
