### PR TITLE
Rotate PDF text field when page is in landscape orientation. Fixes #154

### DIFF
--- a/jasperreports/src/net/sf/jasperreports/engine/export/JRPdfExporter.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/export/JRPdfExporter.java
@@ -3051,8 +3051,12 @@ public class JRPdfExporter extends JRAbstractExporter<PdfReportConfiguration, Pd
 		{
 			pdfTextField.setOptions(pdfTextField.getOptions() | TextField.MULTILINE);
 		}
-		
-//		text.setRotation(90);
+
+		if (pageFormat.getOrientation() == OrientationEnum.LANDSCAPE)
+		{
+			pdfTextField.setRotation(90);
+		}
+
 		pdfTextField.setVisibility(TextField.VISIBLE);
 		
 		PdfFormField field = null;


### PR DESCRIPTION
Rotate pdf text field when report is set to landscape.