### PR TITLE
Update FasterXML Jackson dependencies fixes CVE-2020-25649

### DIFF
--- a/jasperreports/ivy.xml
+++ b/jasperreports/ivy.xml
@@ -14,9 +14,9 @@
 		<dependency org="antlr" name="antlr" rev="2.7.5"/>
 		<dependency org="com.adobe.xmp" name="xmpcore" rev="5.1.3"/>
 		<dependency org="com.beust" name="jcommander" rev="1.27" conf="test->*"/>
-		<dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.10.0" conf="compile,annotations->*"/>
-		<dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.10.0" conf="compile,annotations->*"/>
-		<dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.10.0" conf="compile,annotations->*"/>
+		<dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.10.5" conf="compile,annotations->*"/>
+		<dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.10.5" conf="compile,annotations->*"/>
+		<dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.10.5.1" conf="compile,annotations->*"/>
 		<dependency org="com.github.kklisura.cdt" name="cdt-java-client" rev="2.0.0"/>
 		<dependency org="com.google.zxing" name="core" rev="3.4.0"/>
 		<dependency org="com.lowagie" name="itext" rev="2.1.7.js8"/>

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -378,21 +378,21 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.10.0</version>
+			<version>2.10.5</version>
 			<scope>compile</scope>
 			<optional>false</optional>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.10.0</version>
+			<version>2.10.5.1</version>
 			<scope>compile</scope>
 			<optional>false</optional>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.10.0</version>
+			<version>2.10.5</version>
 			<scope>compile</scope>
 			<optional>false</optional>
 		</dependency>


### PR DESCRIPTION
Update FasterXML Jackson dependencies fixes CVE-2020-25649.

https://nvd.nist.gov/vuln/detail/CVE-2020-25649
 