### PR TITLE
Close DIV element in HtmlExporter

### DIFF
--- a/jasperreports/src/net/sf/jasperreports/engine/export/HtmlExporter.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/export/HtmlExporter.java
@@ -2892,7 +2892,10 @@ public class HtmlExporter extends AbstractHtmlExporter<HtmlReportConfiguration, 
 			writer.write("</span>");
 		}
 		
-		if (firstLineIndent != null || justifyLastLine)
+		if (firstLineIndent != null || justifyLastLine ||
+                        (leftIndent != null && leftIndent > 0) ||
+                        (rightIndent != null && rightIndent > 0)
+			)
 		{
 			writer.write("</div>");
 		}


### PR DESCRIPTION
If firstLineIndent is null and justifyLastLine is false, but leftIndent is greater then 0 or rightIndent is greater then 0, then you opened a div element (see [#2814 - #2819] and #2820). So, you need also to close that div element.