### PR TITLE
Update repository links to support Maven 3.8.1

### DIFF
--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -521,17 +521,17 @@
 	<repositories>
 		<repository>
 			<id>jaspersoft-third-party</id>
-			<url>http://jaspersoft.jfrog.io/jaspersoft/third-party-ce-artifacts/</url>
+			<url>https://jaspersoft.jfrog.io/jaspersoft/third-party-ce-artifacts/</url>
 		</repository>
 		<repository>
 			<id>jr-ce-snapshots</id>
 			<name>JasperReports CE Snapshots</name>
-			<url>http://jaspersoft.jfrog.io/jaspersoft/jr-ce-snapshots</url>
+			<url>https://jaspersoft.jfrog.io/jaspersoft/jr-ce-snapshots</url>
 		</repository>
 		<repository>
 			<id>jr-ce-releases</id>
 			<name>JasperReports CE Releases</name>
-			<url>http://jaspersoft.jfrog.io/jaspersoft/jr-ce-releases</url>
+			<url>https://jaspersoft.jfrog.io/jaspersoft/jr-ce-releases</url>
 		</repository>
 	</repositories>
 	<build>


### PR DESCRIPTION
Maven 3.8.1 blocks http requests to repositorys by default
https://maven.apache.org/docs/3.8.1/release-notes.html

Changing to HTTPS to fix this.