### PR TITLE
Performance fixes for html-markup and according to findings in issue #236

### DIFF
--- a/jasperreports/src/net/sf/jasperreports/engine/fill/JRFillTextElement.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/fill/JRFillTextElement.java
@@ -1136,7 +1136,7 @@ public abstract class JRFillTextElement extends JRFillElement implements JRTextE
 	{
 		text = JRStringUtil.replaceCRwithLF(text);
 		
-		if (text != null)
+		if (text != null && text.contains("<"))
 		{
 			String markup = getMarkup();
 			if (


### PR DESCRIPTION
This PR fixes some performance issues found when load testing and recording report generation.
We make use of text fields with html-markup that very often doesn't contain any html and hence a lot of time and resources is spent in processing markup that is unnecessary 

- Use InheritableThreadLocal to let sub report thread utilize previously created JRStyledTextParser
- Drop out early in markup processing if text doesn't contain any xml start tags

This fix improved performance by a multitude for us.

#236 