### PR TITLE
[#12731] - Add automatic module name to jar manifest

### DIFF
--- a/jasperreports/demo/samples/htmlcomponent/pom.xml
+++ b/jasperreports/demo/samples/htmlcomponent/pom.xml
@@ -123,6 +123,7 @@
 				<configuration>
 					<archive>
 						<manifestEntries>
+							<Automatic-Module-Name>net.sf.jasperreports.components.html</Automatic-Module-Name>
 							<Built-By>${project.organization.name}</Built-By>
 						</manifestEntries>
 						<manifestSections>

--- a/jasperreports/ext/chart-customizers/pom.xml
+++ b/jasperreports/ext/chart-customizers/pom.xml
@@ -150,6 +150,7 @@
 				<configuration>
 					<archive>
 						<manifestEntries>
+							<Automatic-Module-Name>net.sf.jasperreports.customizers</Automatic-Module-Name>
 							<Built-By>${project.organization.name}</Built-By>
 						</manifestEntries>
 						<manifestSections>

--- a/jasperreports/ext/chart-themes/pom.xml
+++ b/jasperreports/ext/chart-themes/pom.xml
@@ -142,6 +142,7 @@
 				<configuration>
 					<archive>
 						<manifestEntries>
+							<Automatic-Module-Name>net.sf.jasperreports.chartthemes</Automatic-Module-Name>
 							<Built-By>${project.organization.name}</Built-By>
 						</manifestEntries>
 						<manifestSections>

--- a/jasperreports/ext/custom-visualization/pom.xml
+++ b/jasperreports/ext/custom-visualization/pom.xml
@@ -110,6 +110,7 @@
 				<configuration>
 					<archive>
 						<manifestEntries>
+							<Automatic-Module-Name>net.sf.jasperreports.customvisualization</Automatic-Module-Name>
 							<Built-By>${project.organization.name}</Built-By>
 						</manifestEntries>
 						<manifestSections>

--- a/jasperreports/ext/fonts/pom.xml
+++ b/jasperreports/ext/fonts/pom.xml
@@ -84,6 +84,7 @@
 				<configuration>
 					<archive>
 						<manifestEntries>
+							<Automatic-Module-Name>net.sf.jasperreports.fonts</Automatic-Module-Name>
 							<Built-By>${project.organization.name}</Built-By>
 						</manifestEntries>
 						<manifestSections>

--- a/jasperreports/ext/functions/pom.xml
+++ b/jasperreports/ext/functions/pom.xml
@@ -110,6 +110,7 @@
 				<configuration>
 					<archive>
 						<manifestEntries>
+							<Automatic-Module-Name>net.sf.jasperreports.functions</Automatic-Module-Name>
 							<Built-By>${project.organization.name}</Built-By>
 						</manifestEntries>
 						<manifestSections>

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -654,6 +654,9 @@
 				<version>3.1.0</version>
 				<configuration>
 					<archive>
+						<manifestEntries>
+							<Automatic-Module-Name>net.sf.jasperreports</Automatic-Module-Name>
+						</manifestEntries>
 						<manifestFile>${basedir}/target/classes/META-INF/MANIFEST.MF</manifestFile>
 					</archive>
 				</configuration>

--- a/jasperreports/tools/annotation-processors/pom.xml
+++ b/jasperreports/tools/annotation-processors/pom.xml
@@ -113,6 +113,7 @@
 				<configuration>
 					<archive>
 						<manifestEntries>
+							<Automatic-Module-Name>net.sf.jasperreports.annotations</Automatic-Module-Name>
 							<Built-By>${project.organization.name}</Built-By>
 						</manifestEntries>
 						<manifestSections>

--- a/jasperreports/tools/metadata/pom.xml
+++ b/jasperreports/tools/metadata/pom.xml
@@ -105,6 +105,7 @@
 				<configuration>
 					<archive>
 						<manifestEntries>
+              				<Automatic-Module-Name>net.sf.jasperreports.metadata</Automatic-Module-Name>
 							<Built-By>${project.organization.name}</Built-By>
 						</manifestEntries>
 						<manifestSections>


### PR DESCRIPTION
maven-compiler-plugin print out the following error message currently: "Required filename-based automodules detected: [jasperreports-6.18.1.jar]. Please don't publish this project to a public artifact repository!". 