### PR TITLE
fix reference to new xmpcore library version

### DIFF
--- a/jasperreports/src/net/sf/jasperreports/engine/export/PdfXmpCreator.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/export/PdfXmpCreator.java
@@ -63,7 +63,7 @@ public class PdfXmpCreator
 	{
 		try
 		{
-			Class.forName("com.adobe.xmp.XMPMetaFactory");
+			Class.forName("com.adobe.internal.xmp.XMPMetaFactory");
 			return true;
 		} catch (ClassNotFoundException e)
 		{


### PR DESCRIPTION
Adobe XMP Library was not found and therefore not used because of package name changes after updating to new version in commit 27a94abb0469ba7933d5985c0293716c858007c9 (JRL 6.19.0)