### PR TITLE
BUG-Fix in multi-threading executions

### DIFF
--- a/jasperreports/src/net/sf/jasperreports/repo/RepositoryUtil.java
+++ b/jasperreports/src/net/sf/jasperreports/repo/RepositoryUtil.java
@@ -26,6 +26,7 @@ package net.sf.jasperreports.repo;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 
 import net.sf.jasperreports.engine.JRException;
@@ -85,8 +86,8 @@ public final class RepositoryUtil
 		{
 			return cachedServices;
 		}
-		
-		List<RepositoryService> services = context.getJasperReportsContext().getExtensions(RepositoryService.class);
+
+		List<RepositoryService> services = new CopyOnWriteArrayList<>(context.getJasperReportsContext().getExtensions(RepositoryService.class));
 		
 		// set if not already set
 		if (repositoryServices.compareAndSet(null, services))


### PR DESCRIPTION
When using multi-threaded creation of jasper reports a ConcurrentModidicationException will be sometimes thrown (the more threads the higher chance)

It crashed in the line:   for (RepositoryService service : service)

By using a CopyOnWriteArrayList solves the issue. Testet with 30 Threads creating PDFs

Fix for Exception:
java.util.ConcurrentModificationException
	at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:901)
	at java.util.ArrayList$Itr.next(ArrayList.java:851)
	at net.sf.jasperreports.repo.RepositoryUtil.getResourceInfo(RepositoryUtil.java:239)
	at net.sf.jasperreports.engine.fill.JRFillSubreport.getReportSource(JRFillSubreport.java:394)
	at net.sf.jasperreports.engine.fill.JRFillSubreport.evaluateReportSource(JRFillSubreport.java:365)
	at net.sf.jasperreports.engine.fill.JRFillSubreport.evaluateSubreport(JRFillSubreport.java:506)
	at net.sf.jasperreports.engine.fill.JRFillSubreport.evaluate(JRFillSubreport.java:357)
	at net.sf.jasperreports.engine.fill.JRFillElementContainer.evaluate(JRFillElementContainer.java:383)
	at net.sf.jasperreports.engine.fill.JRFillBand.evaluate(JRFillBand.java:548)
	at net.sf.jasperreports.engine.fill.JRVerticalFiller.fillColumnBand(JRVerticalFiller.java:2613)
	at net.sf.jasperreports.engine.fill.JRVerticalFiller.fillDetail(JRVerticalFiller.java:836)
	at net.sf.jasperreports.engine.fill.JRVerticalFiller.fillReportStart(JRVerticalFiller.java:275)
	at net.sf.jasperreports.engine.fill.JRVerticalFiller.fillReport(JRVerticalFiller.java:119)
	at net.sf.jasperreports.engine.fill.JRBaseFiller.fill(JRBaseFiller.java:622)
	at net.sf.jasperreports.engine.fill.BaseReportFiller.fill(BaseReportFiller.java:414)
	at net.sf.jasperreports.engine.fill.JRFiller.fill(JRFiller.java:120)
	at net.sf.jasperreports.engine.fill.JRFiller.fill(JRFiller.java:103)
	at net.sf.jasperreports.engine.JasperFillManager.fill(JasperFillManager.java:530)
	at de.kvn.abrechnung.regelverarbeitung.model.BatchDo.runJasperTask(BatchDo.java:119)
	at de.kvn.abrechnung.regelverarbeitung.model.BatchDo.call(BatchDo.java:93)
	at de.kvn.abrechnung.regelverarbeitung.model.BatchDo.call(BatchDo.java:21)
	at java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:266)
	at java.util.concurrent.FutureTask.run(FutureTask.java)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:748)