### PR TITLE
FIXED loading sub report resource from current context location

### DIFF
--- a/jasperreports/src/net/sf/jasperreports/repo/RepositoryUtil.java
+++ b/jasperreports/src/net/sf/jasperreports/repo/RepositoryUtil.java
@@ -23,16 +23,19 @@
  */
 package net.sf.jasperreports.repo;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
-
 import net.sf.jasperreports.engine.JRException;
 import net.sf.jasperreports.engine.JasperReport;
 import net.sf.jasperreports.engine.JasperReportsContext;
 import net.sf.jasperreports.engine.ReportContext;
 import net.sf.jasperreports.engine.util.JRLoader;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 
 /**
@@ -50,6 +53,8 @@ public final class RepositoryUtil
 	
 
 	private RepositoryContext context;
+  
+  private static final Log log = LogFactory.getLog(RepositoryUtil.class);
 
 
 	/**
@@ -147,6 +152,17 @@ public final class RepositoryUtil
 			for (RepositoryService service : services)
 			{
 				resource = service.getResource(context, location, resourceType);
+        if (resource==null)
+        {
+          try
+          {
+            resource = service.getResource(context, context.getResourceContext().getContextLocation() + File.separator + location, resourceType);
+          }
+          catch (Exception ex)
+          {
+            log.debug("Error with getting resource from resource context location", ex);
+          }
+        }
 				if (resource != null)
 				{
 					break;


### PR DESCRIPTION
After migration from version 6.2.0 to 6.20.0, all our reports with sub-reports in the runtime were getting 
"Resource not found at XXXXX"
In more than 1000 templates, we are referencing our sub-reports without any predefined SUBREPORT_DIR, just put <name_of_subreport>.jasper with the assumption it will try to find sub-report in the current folder, no matter what that folder is; some external folder, or resource in the classpath or whatever; 
This is the fix for this, or at least we think it is :-)