### PR TITLE
Allow grid rows produced by frames docx exporter with allow resize enabled to grow

### DIFF
--- a/jasperreports/src/net/sf/jasperreports/engine/export/ooxml/JRDocxExporter.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/export/ooxml/JRDocxExporter.java
@@ -667,7 +667,8 @@ public class JRDocxExporter extends JRAbstractExporter<DocxReportConfiguration, 
 				allowRowResize = 
 					isFlexibleRowHeight 
 					&& (allowRowResize 
-						|| (gridCell.getElement() instanceof JRPrintText 
+						|| (gridCell.getElement() instanceof JRPrintText
+						    || gridCell.getElement() instanceof JRPrintFrame
 							|| (gridCell.getType() == JRExporterGridCell.TYPE_OCCUPIED_CELL
 								&& ((OccupiedGridCell)gridCell).getOccupier().getElement() instanceof JRPrintText)
 							)


### PR DESCRIPTION
The docx exporter has a property that can be set to allow grid rows to grow to fit their content: net.sf.jasperreports.export.docx.flexible.row.height.

When this property is set to true, table rows produced by the grid layout have their heights set to 'At least' rather than 'Exactly' which makes it far easier for users to manually add content the documents generated by Jasper.

Unfortunately, table rows that come from frames do not honor this setting, and so it is not possible to add content in or around frames.

This simple change makes the setting also apply to rows produced by frames, making the resulting output much more easily manually editable.