### PR TITLE
fix class cast exception in map component

### DIFF
--- a/jasperreports/src/net/sf/jasperreports/components/map/imageprovider/MapElementImageProvider.java
+++ b/jasperreports/src/net/sf/jasperreports/components/map/imageprovider/MapElementImageProvider.java
@@ -23,6 +23,8 @@
  */
 package net.sf.jasperreports.components.map.imageprovider;
 
+import java.util.LinkedHashMap;
+import java.util.stream.Collectors;
 import net.sf.jasperreports.components.map.MapComponent;
 import net.sf.jasperreports.engine.JRException;
 import net.sf.jasperreports.engine.JRGenericPrintElement;
@@ -86,7 +88,7 @@ public class MapElementImageProvider extends AbstractMapElementImageProvider
 		String reqParams = (String)element.getParameterValue(MapComponent.PARAMETER_REQ_PARAMS);
 		String markers ="";
 
-		List<Map<String,Object>> markerList = (List<Map<String,Object>>)element.getParameterValue(MapComponent.PARAMETER_MARKERS);
+		List<Map<String,Object>> markerList = getMarkersAsFlatList(element);
 		if(markerList != null && !markerList.isEmpty())
 		{
 			String currentMarkers = "";
@@ -197,4 +199,9 @@ public class MapElementImageProvider extends AbstractMapElementImageProvider
 		return imageLocation;
 	}
 
+	private List<Map<String,Object>> getMarkersAsFlatList(JRGenericPrintElement element) {
+		return ((LinkedHashMap<String, LinkedHashMap<String, List<Map<String,Object>>>>) element.getParameterValue(MapComponent.PARAMETER_MARKERS))
+				.entrySet().stream().flatMap(series -> series.getValue().entrySet().stream().flatMap(entries -> entries.getValue().stream()))
+				.collect(Collectors.toList());
+	}
 }


### PR DESCRIPTION
Between 6.20.1 and 6.20.2, the returned objects class type for the 'markers' parameter changed. This leads to a ClassCastException.

The new returned object contains an additional layer (LinkedHashList) in which the markers are  grouped by different names. My fix creates a flat list from all provided groups of markers to make the existing code work again.