### PR TITLE
Pass expected type to getObject()

### DIFF
--- a/jasperreports/src/net/sf/jasperreports/engine/JRResultSetDataSource.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/JRResultSetDataSource.java
@@ -398,7 +398,7 @@ public class JRResultSetDataSource implements JRDataSource
 				}
 				else
 				{
-					objValue = resultSet.getObject(columnIndex);
+					objValue = resultSet.getObject(columnIndex, clazz);
 				}
 			}
 			catch (Exception e)


### PR DESCRIPTION
This change improves support for custom or unusual data types in JDBC drivers. MS SQL Server has a DATETIMEOFFSET type, which mssql-jdbc maps to `microsoft.sql.DateTimeOffset` by default. The driver also knows how to return a `java.time.OffsetDateTime` for such columns, but you have to explicitly ask for it.