### PR TITLE
Update commons-collections4 library to 4.3. Fixes CWE-674.

### DIFF
--- a/jasperreports/pom-common.xml
+++ b/jasperreports/pom-common.xml
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-collections4</artifactId>
-			<version>4.2</version>
+			<version>4.3</version>
 			<scope>compile</scope>
 			<optional>false</optional>
 		</dependency>


### PR DESCRIPTION
It fix this issue: https://devhub.checkmarx.com/cve-details/Cx78f40514-81ff/