### PR TITLE
fix gh-411: add support for remaining java.time parameters (OffsetDateTime and OffsetTime) to jdbc query executer

### DIFF
--- a/jasperreports/src/net/sf/jasperreports/engine/query/JRJdbcQueryExecuterFactory.java
+++ b/jasperreports/src/net/sf/jasperreports/engine/query/JRJdbcQueryExecuterFactory.java
@@ -207,7 +207,9 @@ public class JRJdbcQueryExecuterFactory extends AbstractQueryExecuterFactory imp
 				java.sql.Time.class.getName(),
 				java.time.LocalDate.class.getName(),
 				java.time.LocalDateTime.class.getName(),
-				java.time.LocalTime.class.getName()
+				java.time.LocalTime.class.getName(),
+				java.time.OffsetDateTime.class.getName(),
+				java.time.OffsetTime.class.getName()
 				};
 
 		Arrays.sort(queryParameterClassNames);


### PR DESCRIPTION
This adds support for the remaining two `java.time` classes that were added in JDBC 4.2.