### PR TITLE
ATLAS-4777: Fix double reference on Detail Split Type "Prevent"

### DIFF
--- a/jasperreports/build.xml
+++ b/jasperreports/build.xml
@@ -3,8 +3,8 @@
 	<description>Helps build the JasperReports distribution files.</description>
 
 	<property name="organization" value="TIBCO Software Inc."/>
-	<property name="version" value="master-SNAPSHOT"/>
-	<property name="scm-tag" value="master-SNAPSHOT"/>
+	<property name="version" value="6.17.0-landclan"/>
+	<property name="scm-tag" value="6.17.0-landclan"/>
 
 	<path id="project-classpath">
 		<path refid="project-lib"/>
@@ -14,11 +14,11 @@
 	<target name="compile" description="Compiles the java source files of the library.">
 		<mkdir dir="./build/classes"/>
 		<ivy:configure file="./ivysettings.xml" override="true"/>
-		<ivy:cachepath pathid="project-lib" log="download-only" conf="compile"/> 
+		<ivy:cachepath pathid="project-lib" log="download-only" conf="compile"/>
 		<ivy:cachepath pathid="annotations-lib" log="download-only" conf="annotations"/>
 		<pathconvert property="annotations-paths" refid="annotations-lib"/>
 		<javac destdir="./build/classes" debug="true" optimize="false" target="1.8" source="1.8"
-				encoding="UTF-8" includeantruntime="false" excludes="**/package-info.java">
+			   encoding="UTF-8" includeantruntime="false" excludes="**/package-info.java">
 			<classpath refid="project-classpath"/>
 			<src path="./src"/>
 			<compilerarg value="-Xlint:-unchecked"/>
@@ -30,7 +30,7 @@
 			<compilerarg value="-ApropertiesDoc=${basedir}/docs/config.reference.xml"/>
 			<compilerarg value="-AconfigReferenceOut=${basedir}/build/config.reference.xml"/>
 		</javac>
-		
+
 		<copy todir="./build/classes">
 			<fileset dir="./src">
 				<include name="**/*.dtd"/>
@@ -57,9 +57,9 @@
 		</copy>
 
 		<exec executable="git" outputproperty="git.revision" failifexecutionfails="false" errorproperty="">
-			<arg value="log" />
-			<arg value="-1" />
-			<arg value="--pretty=format:%H" />
+			<arg value="log"/>
+			<arg value="-1"/>
+			<arg value="--pretty=format:%H"/>
 		</exec>
 		<condition property="repository.version" value="${git.revision}" else="unknown">
 			<and>
@@ -81,7 +81,7 @@
 			</fileset>
 		</copy>
 	</target>
-	
+
 	<target name="antlr.generate" description="Generates source files for ANTLR grammars">
 		<ivy:cachepath pathid="project-lib" log="download-only" conf="compile"/>
 		<antlr target="src/net/sf/jasperreports/olap/mapping/mapping.g">
@@ -93,7 +93,7 @@
 	</target>
 
 	<target name="jar" depends="compile" description="Builds the JasperReports JAR file.">
-		<mkdir dir="./dist"/> 
+		<mkdir dir="./dist"/>
 		<jar jarfile="./dist/jasperreports-${version}.jar" manifest="build/classes/META-INF/MANIFEST.MF">
 			<fileset dir="./build/classes"/>
 			<fileset dir="./">
@@ -102,11 +102,11 @@
 			</fileset>
 		</jar>
 	</target>
-	
+
 	<target name="alljars" depends="jar, javaflow" description="Builds all JasperReports JAR files."/>
 
 	<target name="javaflow" depends="compile" description="Builds the JavaFlow instrumentated JAR file.">
-		<ivy:cachepath pathid="project-lib" log="download-only" conf="javaflow"/> 
+		<ivy:cachepath pathid="project-lib" log="download-only" conf="javaflow"/>
 		<taskdef name="javaflow" classname="net.sf.jasperreports.ant.JavaflowRewriteTask">
 			<classpath refid="project-classpath"/>
 		</taskdef>
@@ -116,9 +116,9 @@
 		</copy>
 
 		<replaceregexp
-			file="./build/javaflow/default.jasperreports.properties"
-			match="net.sf.jasperreports.subreport.runner.factory\=[\w\.]*"
-			replace="net.sf.jasperreports.subreport.runner.factory=net.sf.jasperreports.engine.fill.JRContinuationSubreportRunnerFactory">
+				file="./build/javaflow/default.jasperreports.properties"
+				match="net.sf.jasperreports.subreport.runner.factory\=[\w\.]*"
+				replace="net.sf.jasperreports.subreport.runner.factory=net.sf.jasperreports.engine.fill.JRContinuationSubreportRunnerFactory">
 		</replaceregexp>
 
 		<javaflow srcdir="./build/javaflow" destdir="./build/javaflow" mode="asm5">
@@ -132,7 +132,7 @@
 			<include name="net/sf/jasperreports/engine/fill/FillerSubreportParent.class"/>
 		</javaflow>
 
-		<mkdir dir="./dist"/> 
+		<mkdir dir="./dist"/>
 		<jar jarfile="./dist/jasperreports-javaflow-${version}.jar" manifest="build/classes/META-INF/MANIFEST.MF">
 			<fileset dir="./build/javaflow"/>
 			<fileset dir="./">
@@ -149,10 +149,10 @@
 	</target>
 
 	<target name="javadoc" description="Compiles the library API documentation.">
-		<mkdir dir="./dist/docs/api"/> 
+		<mkdir dir="./dist/docs/api"/>
 		<delete dir="./dist/docs/api/net"/>
 		<delete>
-			<fileset dir="./dist/docs/api" includes="**/*.*" />
+			<fileset dir="./dist/docs/api" includes="**/*.*"/>
 		</delete>
 		<ivy:cachepath pathid="project-lib" log="download-only" conf="docs"/>
 		<condition property="javadoc-arg" value="-Xdoclint:none" else="">
@@ -168,17 +168,17 @@
 			<format property="CURRENT_YEAR" pattern="yyyy" locale="en"/>
 		</tstamp>
 		<javadoc packagenames="net.sf.jasperreports.*"
-				sourcepath="./src"
-				destdir="./dist/docs/api"
-				author="true"
-				version="true"
-				use="true"
-				windowtitle="JasperReports ${version} API"
-				maxmemory="1024m"
-				failonerror="true"
-				encoding="UTF-8">
+				 sourcepath="./src"
+				 destdir="./dist/docs/api"
+				 author="true"
+				 version="true"
+				 use="true"
+				 windowtitle="JasperReports ${version} API"
+				 maxmemory="1024m"
+				 failonerror="true"
+				 encoding="UTF-8">
 			<doctitle>
-<![CDATA[
+				<![CDATA[
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
 <tr valign="middle">
 <td nowrap="true"><span style="font-decoration:none;font-family:Arial,Helvetica,sans-serif;font-size:28px;font-weight:normal;color:#000000;">JasperReports API (version ${version})</span></td><td align="right"><img border="0" src="resources/jasperreports.svg"></td>
@@ -187,7 +187,7 @@
 ]]>
 			</doctitle>
 			<bottom>
-<![CDATA[
+				<![CDATA[
 <span style="font-decoration:none;font-family:Arial,Helvetica,sans-serif;font-size:8pt;font-style:normal;color:#000000;">&copy; 2001 - ${CURRENT_YEAR} TIBCO Software Inc. <a href="http://www.jaspersoft.com" target="_blank" style="color:#000000;">www.jaspersoft.com</a></span>
 ]]>
 			</bottom>
@@ -203,7 +203,7 @@
 	</target>
 
 	<target name="preparedocs" description="Prepares Documentation Folder.">
-		<mkdir dir="./dist/docs"/> 
+		<mkdir dir="./dist/docs"/>
 		<copy todir="./dist/docs">
 			<fileset dir="docs">
 				<include name="resources/*.*"/>
@@ -213,52 +213,58 @@
 			</fileset>
 		</copy>
 	</target>
-	
+
 	<target name="schemaref" description="Generates the Schema Reference.">
-		<ivy:cachepath pathid="project-lib" log="download-only" conf="docs"/> 
-		<xslt basedir="src/net/sf/jasperreports/engine/dtds" in="src/net/sf/jasperreports/engine/dtds/jasperreport.xsd" destdir="dist/docs" style="docs/schema.reference.xsl" out="./dist/docs/schema.reference.html">
+		<ivy:cachepath pathid="project-lib" log="download-only" conf="docs"/>
+		<xslt basedir="src/net/sf/jasperreports/engine/dtds" in="src/net/sf/jasperreports/engine/dtds/jasperreport.xsd"
+			  destdir="dist/docs" style="docs/schema.reference.xsl" out="./dist/docs/schema.reference.html">
 			<param name="sf.net" expression="${sf.net}"/>
 			<param name="version" expression="${version}"/>
 			<classpath refid="project-classpath"/>
 		</xslt>
 	</target>
-	
+
 	<target name="partschemaref" description="Generates the Report Parts Schema Reference.">
-		<ivy:cachepath pathid="project-lib" log="download-only" conf="docs"/> 
-		<xslt basedir="src/net/sf/jasperreports/parts" in="src/net/sf/jasperreports/parts/parts.xsd" destdir="dist/docs" style="docs/parts.schema.reference.xsl" out="./dist/docs/parts.schema.reference.html">
+		<ivy:cachepath pathid="project-lib" log="download-only" conf="docs"/>
+		<xslt basedir="src/net/sf/jasperreports/parts" in="src/net/sf/jasperreports/parts/parts.xsd" destdir="dist/docs"
+			  style="docs/parts.schema.reference.xsl" out="./dist/docs/parts.schema.reference.html">
 			<param name="sf.net" expression="${sf.net}"/>
 			<param name="version" expression="${version}"/>
 			<classpath refid="project-classpath"/>
 		</xslt>
 	</target>
-	
+
 	<target name="componentschemaref" description="Generates the Component Schema Reference.">
-		<ivy:cachepath pathid="project-lib" log="download-only" conf="docs"/> 
-		<xslt basedir="src/net/sf/jasperreports/components" in="src/net/sf/jasperreports/components/components.xsd" destdir="dist/docs" style="docs/components.schema.reference.xsl" out="./dist/docs/components.schema.reference.html">
+		<ivy:cachepath pathid="project-lib" log="download-only" conf="docs"/>
+		<xslt basedir="src/net/sf/jasperreports/components" in="src/net/sf/jasperreports/components/components.xsd"
+			  destdir="dist/docs" style="docs/components.schema.reference.xsl"
+			  out="./dist/docs/components.schema.reference.html">
 			<param name="sf.net" expression="${sf.net}"/>
 			<param name="version" expression="${version}"/>
 			<classpath refid="project-classpath"/>
 		</xslt>
 	</target>
-	
+
 	<target name="configref" description="Generates the Configuration Reference." depends="compile">
-		<ivy:cachepath pathid="project-lib" log="download-only" conf="docs"/> 
-		<xslt basedir="docs" in="build/config.reference.xml" destdir="dist/docs" style="docs/config.reference.xsl" out="./dist/docs/config.reference.html">
+		<ivy:cachepath pathid="project-lib" log="download-only" conf="docs"/>
+		<xslt basedir="docs" in="build/config.reference.xml" destdir="dist/docs" style="docs/config.reference.xsl"
+			  out="./dist/docs/config.reference.html">
 			<param name="sf.net" expression="${sf.net}"/>
 			<param name="version" expression="${version}"/>
 			<classpath refid="project-classpath"/>
 		</xslt>
 	</target>
-	
+
 	<target name="sampleref" depends="compile" description="Generates the Sample Reference.">
-		<ivy:cachepath pathid="project-lib" log="download-only" conf="docs"/> 
-		<xslt basedir="docs" in="docs/sample.reference.xml" destdir="dist/docs" style="docs/sample.reference.xsl" out="./dist/docs/sample.reference.html">
+		<ivy:cachepath pathid="project-lib" log="download-only" conf="docs"/>
+		<xslt basedir="docs" in="docs/sample.reference.xml" destdir="dist/docs" style="docs/sample.reference.xsl"
+			  out="./dist/docs/sample.reference.html">
 			<param name="sf.net" expression="${sf.net}"/>
 			<param name="version" expression="${version}"/>
 			<classpath refid="project-classpath"/>
 		</xslt>
-		<mkdir dir="./dist/docs/sample.reference"/> 
-		<mkdir dir="./dist/docs/resources"/> 
+		<mkdir dir="./dist/docs/sample.reference"/>
+		<mkdir dir="./dist/docs/resources"/>
 		<xslt basedir="demo/samples" destdir="dist/docs/sample.reference" style="./docs/sample.xsl">
 			<param name="sf.net" expression="${sf.net}"/>
 			<param name="version" expression="${version}"/>
@@ -279,29 +285,32 @@
 			</fileset>
 		</copy>
 		<ant dir="./demo/samples/functions" target="test"/>
-		<copy todir="./dist/docs/sample.reference/functions" file="./demo/samples/functions/build/reports/FunctionsReport.html"/>
-		<mkdir dir="./dist/docs/sample.reference/functions/FunctionsReport.html_files"/> 
+		<copy todir="./dist/docs/sample.reference/functions"
+			  file="./demo/samples/functions/build/reports/FunctionsReport.html"/>
+		<mkdir dir="./dist/docs/sample.reference/functions/FunctionsReport.html_files"/>
 		<copy todir="./dist/docs/sample.reference/functions/FunctionsReport.html_files">
 			<fileset dir="./demo/samples/functions/build/reports/FunctionsReport.html_files"/>
 		</copy>
 	</target>
-	
-	<target name="docs" depends="preparedocs, javadoc, schemaref, partschemaref, componentschemaref, configref, sampleref" description="Generates all documentation."/>
+
+	<target name="docs"
+			depends="preparedocs, javadoc, schemaref, partschemaref, componentschemaref, configref, sampleref"
+			description="Generates all documentation."/>
 
 	<target name="retrievelibs" description="Retrieve dependencies with Apache Ivy">
 		<ivy:retrieve conf="compile, javaflow, test" pattern="dist/lib/[artifact](-[classifier])-[revision].[ext]"/>
 	</target>
-	
+
 	<target name="test" depends="compile" description="Compiles the test sources and runs the tests">
 		<ivy:cachepath pathid="test-compile-libs" log="download-only" conf="test"/>
 		<path id="test-compile">
 			<path refid="test-compile-libs"/>
 			<pathelement location="./build/classes"/>
 		</path>
-		
+
 		<mkdir dir="./build/test-classes"/>
-		<javac destdir="./build/test-classes" debug="true" optimize="false" target="1.8" source="1.8" 
-				encoding="UTF-8" includeantruntime="false">
+		<javac destdir="./build/test-classes" debug="true" optimize="false" target="1.8" source="1.8"
+			   encoding="UTF-8" includeantruntime="false">
 			<classpath refid="test-compile"/>
 			<src path="./tests"/>
 			<compilerarg value="-Xlint:-unchecked"/>
@@ -322,7 +331,7 @@
 				<include name="**/*.err"/>
 			</fileset>
 		</copy>
-		
+
 		<taskdef resource="testngtasks" classpathref="test-compile"/>
 		<testng outputdir="build/test-output" haltonfailure="true" haltonskipped="true">
 			<classpath>
@@ -330,9 +339,9 @@
 				<pathelement location="./build/test-classes"/>
 				<pathelement location="./ext/fonts"/>
 			</classpath>
-			<classfileset dir="./build/test-classes" includes="**/*Test.class" />
+			<classfileset dir="./build/test-classes" includes="**/*Test.class"/>
 		</testng>
-		
+
 	</target>
-	
+
 </project>

--- a/jasperreports/enable-landclan-version-in-js.bat
+++ b/jasperreports/enable-landclan-version-in-js.bat
@@ -1,0 +1,28 @@
+@echo off
+rem This script will need to be run with Administrator privileges if your TIBCO Jaspersoft Studio install location is
+rem under Administrator control on your system (which is probably true if you installed it to Program Files).
+
+rem This script will alter your local installation of TIBCO Jaspersoft Studio. Please ensure you read these
+rem instructions first so that you know what has changed.
+
+rem This script takes the custom LandClan jar and overwrites the local official jar that is used by Jaspersoft Studio
+rem so that JS runs with the custom LandClan jar.
+
+rem The install location on my local machine of the relevant jar file is:
+rem C:\Program Files\TIBCO\Jaspersoft Studio-6.17.0\configuration\org.eclipse.osgi\68\0\.cp\lib\jasperreports-6.17.0.jar
+
+rem If we do not already have a backup of the official build, make one now.
+set jarDir="C:\Program Files\TIBCO\Jaspersoft Studio-6.17.0\configuration\org.eclipse.osgi\68\0\.cp\lib\"
+set jarFile="jasperreports-6.17.0.jar"
+set backupFile="%jarFile%.official"
+echo Checking for backup copy of official jar...
+if exist %jarDir%%backupFile% (
+    echo Official jar has already been backed-up.
+) else (
+    echo Creating backup copy of official jar...
+    call copy %jarDir%%jarFile% %jarDir%%backupFile%
+)
+
+echo Copying the custom LandClan version of Jasper Reports to the Jaspersoft Studio library...
+call copy ".\dist\jasperreports-6.17.0-landclan.jar" %jarDir%%jarFile%
+echo Finished.

--- a/jasperreports/enable-official-version-in-js.bat
+++ b/jasperreports/enable-official-version-in-js.bat
@@ -1,0 +1,29 @@
+@echo off
+rem This script will need to be run with Administrator privileges if your TIBCO Jaspersoft Studio install location is
+rem under Administrator control on your system (which is probably true if you installed it to Program Files).
+
+rem This script will alter your local installation of TIBCO Jaspersoft Studio. Please ensure you read these
+rem instructions first so that you know what has changed.
+
+rem This script takes the backup of the official Jasper Reports jar file that was created when the counterpart batch
+rem script 'enable-landclan-version-in-js.bat' was run and re-instates it as the main jar file so that JS runs with the
+rem official jar.
+
+rem The install location on my local machine of the relevant jar file is:
+rem C:\Program Files\TIBCO\Jaspersoft Studio-6.17.0\configuration\org.eclipse.osgi\68\0\.cp\lib\jasperreports-6.17.0.jar
+
+rem If we do not already have a backup of the official build then it is to be assumed that the counterpart batch script
+rem has not been run so there is nothing to do.
+set jarDir="C:\Program Files\TIBCO\Jaspersoft Studio-6.17.0\configuration\org.eclipse.osgi\68\0\.cp\lib\"
+set jarFile="jasperreports-6.17.0.jar"
+set backupFile="%jarFile%.official"
+echo Checking for backup copy of official jar...
+if exist %jarDir%%backupFile% (
+    echo Reverting to the official jar from the backup file...
+    call copy %jarDir%%backupFile% %jarDir%%jarFile%
+    echo Removing the backup...
+    call rm %jarDir%%backupFile%
+    echo Finished.
+) else (
+    echo Official version was already enabled (no backup file was found so this is assumed.)
+)

--- a/jasperreports/install-landclan.bat
+++ b/jasperreports/install-landclan.bat
@@ -1,8 +1,0 @@
-@echo off
-
-echo Installing jasperreports-6.17.0-landclan.jar to local Maven repository...
-call mvn install:install-file -Dfile="dist/jasperreports-6.17.0-landclan.jar" -DpomFile="pom.xml"
-
-echo Updating landclandev01 Maven repository...
-call robocopy "C:\mvn-repository\net\sf\jasperreports\jasperreports\6.17.0-landclan" ^
-  "Y:\mvn-repository\net\sf\jasperreports\jasperreports\6.17.0-landclan" /E

--- a/jasperreports/install-landclan.bat
+++ b/jasperreports/install-landclan.bat
@@ -1,0 +1,8 @@
+@echo off
+
+echo Installing jasperreports-6.17.0-landclan.jar to local Maven repository...
+call mvn install:install-file -Dfile="dist/jasperreports-6.17.0-landclan.jar" -DpomFile="pom.xml"
+
+echo Updating landclandev01 Maven repository...
+call robocopy "C:\mvn-repository\net\sf\jasperreports\jasperreports\6.17.0-landclan" ^
+  "Y:\mvn-repository\net\sf\jasperreports\jasperreports\6.17.0-landclan" /E

--- a/jasperreports/landclan/README.md
+++ b/jasperreports/landclan/README.md
@@ -1,0 +1,4 @@
+The jar file and the pom must be uploaded to the nexus and then
+the nexus maven-releases repository index will need to be rebuilt.
+
+This can be done from the nexus web UI.

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.jasperreports</groupId>
 	<artifactId>jasperreports</artifactId>
-	<version>6.17.0-landclan-15</version>
+	<version>6.17.0-landclan-16</version>
 	<packaging>jar</packaging>
 	<name>JasperReports Library</name>
 	<description>Free Java Reporting Library</description>
@@ -49,7 +49,7 @@
 	</developers>
 	<scm>
 		<connection>scm:git:https://github.com/chris-landclan/jasperreports.git</connection>
-		<tag>6.17.0-landclan-15</tag>
+		<tag>6.17.0-landclan-16</tag>
 		<url>https://github.com/chris-landclan/jasperreports</url>
 	</scm>
 	<properties>

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.jasperreports</groupId>
 	<artifactId>jasperreports</artifactId>
-	<version>6.17.0-landclan-8</version>
+	<version>6.17.0-landclan-9</version>
 	<packaging>jar</packaging>
 	<name>JasperReports Library</name>
 	<description>Free Java Reporting Library</description>
@@ -49,7 +49,7 @@
 	</developers>
 	<scm>
 		<connection>scm:git:https://github.com/chris-landclan/jasperreports.git</connection>
-		<tag>6.17.0-landclan-8</tag>
+		<tag>6.17.0-landclan-9</tag>
 		<url>https://github.com/chris-landclan/jasperreports</url>
 	</scm>
 	<properties>

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.jasperreports</groupId>
 	<artifactId>jasperreports</artifactId>
-	<version>6.17.0-landclan-1</version>
+	<version>6.17.0-landclan-2</version>
 	<packaging>jar</packaging>
 	<name>JasperReports Library</name>
 	<description>Free Java Reporting Library</description>
@@ -49,7 +49,7 @@
 	</developers>
 	<scm>
 		<connection>scm:git:https://github.com/chris-landclan/jasperreports.git</connection>
-		<tag>6.17.0-landclan-1</tag>
+		<tag>6.17.0-landclan-2</tag>
 		<url>https://github.com/chris-landclan/jasperreports</url>
 	</scm>
 	<properties>

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.jasperreports</groupId>
 	<artifactId>jasperreports</artifactId>
-	<version>6.17.0-landclan-6</version>
+	<version>6.17.0-landclan-7</version>
 	<packaging>jar</packaging>
 	<name>JasperReports Library</name>
 	<description>Free Java Reporting Library</description>
@@ -49,7 +49,7 @@
 	</developers>
 	<scm>
 		<connection>scm:git:https://github.com/chris-landclan/jasperreports.git</connection>
-		<tag>6.17.0-landclan-6</tag>
+		<tag>6.17.0-landclan-7</tag>
 		<url>https://github.com/chris-landclan/jasperreports</url>
 	</scm>
 	<properties>

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.jasperreports</groupId>
 	<artifactId>jasperreports</artifactId>
-	<version>6.17.0-landclan-20</version>
+	<version>6.17.0-landclan-21</version>
 	<packaging>jar</packaging>
 	<name>JasperReports Library</name>
 	<description>Free Java Reporting Library</description>
@@ -49,7 +49,7 @@
 	</developers>
 	<scm>
 		<connection>scm:git:https://github.com/chris-landclan/jasperreports.git</connection>
-		<tag>6.17.0-landclan-20</tag>
+		<tag>6.17.0-landclan-21</tag>
 		<url>https://github.com/chris-landclan/jasperreports</url>
 	</scm>
 	<properties>

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.jasperreports</groupId>
 	<artifactId>jasperreports</artifactId>
-	<version>master-SNAPSHOT</version>
+	<version>6.17.0-landclan</version>
 	<packaging>jar</packaging>
 	<name>JasperReports Library</name>
 	<description>Free Java Reporting Library</description>

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.jasperreports</groupId>
 	<artifactId>jasperreports</artifactId>
-	<version>6.17.0-landclan-5</version>
+	<version>6.17.0-landclan-6</version>
 	<packaging>jar</packaging>
 	<name>JasperReports Library</name>
 	<description>Free Java Reporting Library</description>
@@ -49,7 +49,7 @@
 	</developers>
 	<scm>
 		<connection>scm:git:https://github.com/chris-landclan/jasperreports.git</connection>
-		<tag>6.17.0-landclan-5</tag>
+		<tag>6.17.0-landclan-6</tag>
 		<url>https://github.com/chris-landclan/jasperreports</url>
 	</scm>
 	<properties>

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.jasperreports</groupId>
 	<artifactId>jasperreports</artifactId>
-	<version>6.17.0-landclan</version>
+	<version>6.17.0-landclan-1</version>
 	<packaging>jar</packaging>
 	<name>JasperReports Library</name>
 	<description>Free Java Reporting Library</description>
@@ -49,7 +49,7 @@
 	</developers>
 	<scm>
 		<connection>scm:git:https://github.com/chris-landclan/jasperreports.git</connection>
-		<tag>6.17.0-landclan</tag>
+		<tag>6.17.0-landclan-1</tag>
 		<url>https://github.com/chris-landclan/jasperreports</url>
 	</scm>
 	<properties>

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.jasperreports</groupId>
 	<artifactId>jasperreports</artifactId>
-	<version>6.17.0-landclan-10</version>
+	<version>6.17.0-landclan-11</version>
 	<packaging>jar</packaging>
 	<name>JasperReports Library</name>
 	<description>Free Java Reporting Library</description>
@@ -49,7 +49,7 @@
 	</developers>
 	<scm>
 		<connection>scm:git:https://github.com/chris-landclan/jasperreports.git</connection>
-		<tag>6.17.0-landclan-10</tag>
+		<tag>6.17.0-landclan-11</tag>
 		<url>https://github.com/chris-landclan/jasperreports</url>
 	</scm>
 	<properties>

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.jasperreports</groupId>
 	<artifactId>jasperreports</artifactId>
-	<version>6.17.0-landclan-7</version>
+	<version>6.17.0-landclan-8</version>
 	<packaging>jar</packaging>
 	<name>JasperReports Library</name>
 	<description>Free Java Reporting Library</description>
@@ -49,7 +49,7 @@
 	</developers>
 	<scm>
 		<connection>scm:git:https://github.com/chris-landclan/jasperreports.git</connection>
-		<tag>6.17.0-landclan-7</tag>
+		<tag>6.17.0-landclan-8</tag>
 		<url>https://github.com/chris-landclan/jasperreports</url>
 	</scm>
 	<properties>

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.jasperreports</groupId>
 	<artifactId>jasperreports</artifactId>
-	<version>6.17.0-landclan-4</version>
+	<version>6.17.0-landclan-5</version>
 	<packaging>jar</packaging>
 	<name>JasperReports Library</name>
 	<description>Free Java Reporting Library</description>
@@ -49,7 +49,7 @@
 	</developers>
 	<scm>
 		<connection>scm:git:https://github.com/chris-landclan/jasperreports.git</connection>
-		<tag>6.17.0-landclan-4</tag>
+		<tag>6.17.0-landclan-5</tag>
 		<url>https://github.com/chris-landclan/jasperreports</url>
 	</scm>
 	<properties>

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.jasperreports</groupId>
 	<artifactId>jasperreports</artifactId>
-	<version>6.17.0-landclan-14</version>
+	<version>6.17.0-landclan-15</version>
 	<packaging>jar</packaging>
 	<name>JasperReports Library</name>
 	<description>Free Java Reporting Library</description>
@@ -49,7 +49,7 @@
 	</developers>
 	<scm>
 		<connection>scm:git:https://github.com/chris-landclan/jasperreports.git</connection>
-		<tag>6.17.0-landclan-14</tag>
+		<tag>6.17.0-landclan-15</tag>
 		<url>https://github.com/chris-landclan/jasperreports</url>
 	</scm>
 	<properties>

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.jasperreports</groupId>
 	<artifactId>jasperreports</artifactId>
-	<version>6.17.0-landclan-18</version>
+	<version>6.17.0-landclan-19</version>
 	<packaging>jar</packaging>
 	<name>JasperReports Library</name>
 	<description>Free Java Reporting Library</description>
@@ -49,7 +49,7 @@
 	</developers>
 	<scm>
 		<connection>scm:git:https://github.com/chris-landclan/jasperreports.git</connection>
-		<tag>6.17.0-landclan-18</tag>
+		<tag>6.17.0-landclan-19</tag>
 		<url>https://github.com/chris-landclan/jasperreports</url>
 	</scm>
 	<properties>

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.jasperreports</groupId>
 	<artifactId>jasperreports</artifactId>
-	<version>6.17.0-landclan-2</version>
+	<version>6.17.0-landclan-4</version>
 	<packaging>jar</packaging>
 	<name>JasperReports Library</name>
 	<description>Free Java Reporting Library</description>
@@ -49,7 +49,7 @@
 	</developers>
 	<scm>
 		<connection>scm:git:https://github.com/chris-landclan/jasperreports.git</connection>
-		<tag>6.17.0-landclan-2</tag>
+		<tag>6.17.0-landclan-4</tag>
 		<url>https://github.com/chris-landclan/jasperreports</url>
 	</scm>
 	<properties>

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.jasperreports</groupId>
 	<artifactId>jasperreports</artifactId>
-	<version>6.17.0-landclan-17</version>
+	<version>6.17.0-landclan-18</version>
 	<packaging>jar</packaging>
 	<name>JasperReports Library</name>
 	<description>Free Java Reporting Library</description>
@@ -49,7 +49,7 @@
 	</developers>
 	<scm>
 		<connection>scm:git:https://github.com/chris-landclan/jasperreports.git</connection>
-		<tag>6.17.0-landclan-17</tag>
+		<tag>6.17.0-landclan-18</tag>
 		<url>https://github.com/chris-landclan/jasperreports</url>
 	</scm>
 	<properties>

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.jasperreports</groupId>
 	<artifactId>jasperreports</artifactId>
-	<version>6.17.0-landclan-12</version>
+	<version>6.17.0-landclan-13</version>
 	<packaging>jar</packaging>
 	<name>JasperReports Library</name>
 	<description>Free Java Reporting Library</description>
@@ -49,7 +49,7 @@
 	</developers>
 	<scm>
 		<connection>scm:git:https://github.com/chris-landclan/jasperreports.git</connection>
-		<tag>6.17.0-landclan-12</tag>
+		<tag>6.17.0-landclan-13</tag>
 		<url>https://github.com/chris-landclan/jasperreports</url>
 	</scm>
 	<properties>

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -48,9 +48,9 @@
 		</developer>
 	</developers>
 	<scm>
-		<connection>scm:git:https://github.com/TIBCOSoftware/jasperreports.git</connection>
-		<tag>master-SNAPSHOT</tag>
-		<url>https://github.com/TIBCOSoftware/jasperreports</url>
+		<connection>scm:git:https://github.com/chris-landclan/jasperreports.git</connection>
+		<tag>6.17.0-landclan</tag>
+		<url>https://github.com/chris-landclan/jasperreports</url>
 	</scm>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -430,7 +430,7 @@
 		<dependency>
 			<groupId>net.sf.jasperreports</groupId>
 			<artifactId>jasperreports-fonts</artifactId>
-			<version>master-SNAPSHOT</version>
+			<version>6.17.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -499,7 +499,7 @@
 		<dependency>
 			<groupId>net.sf.jasperreports</groupId>
 			<artifactId>jasperreports-metadata</artifactId>
-			<version>master-SNAPSHOT</version>
+			<version>6.17.0</version>
 			<scope>compile</scope>
 			<optional>true</optional>
 		</dependency>
@@ -605,7 +605,7 @@
 					</execution>
 				</executions>
 				<configuration>
-					<doCheck>true</doCheck>
+					<doCheck>false</doCheck>
 					<doUpdate>false</doUpdate>
 				</configuration>
 			</plugin>
@@ -627,7 +627,7 @@
 						<path>
 							<groupId>net.sf.jasperreports</groupId>
 							<artifactId>jasperreports-annotation-processors</artifactId>
-							<version>master-SNAPSHOT</version>
+							<version>6.17.0</version>
 						</path>
 					</annotationProcessorPaths>
 				</configuration>

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.jasperreports</groupId>
 	<artifactId>jasperreports</artifactId>
-	<version>6.17.0-landclan-13</version>
+	<version>6.17.0-landclan-14</version>
 	<packaging>jar</packaging>
 	<name>JasperReports Library</name>
 	<description>Free Java Reporting Library</description>
@@ -49,7 +49,7 @@
 	</developers>
 	<scm>
 		<connection>scm:git:https://github.com/chris-landclan/jasperreports.git</connection>
-		<tag>6.17.0-landclan-13</tag>
+		<tag>6.17.0-landclan-14</tag>
 		<url>https://github.com/chris-landclan/jasperreports</url>
 	</scm>
 	<properties>

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.jasperreports</groupId>
 	<artifactId>jasperreports</artifactId>
-	<version>6.17.0-landclan-11</version>
+	<version>6.17.0-landclan-12</version>
 	<packaging>jar</packaging>
 	<name>JasperReports Library</name>
 	<description>Free Java Reporting Library</description>
@@ -49,7 +49,7 @@
 	</developers>
 	<scm>
 		<connection>scm:git:https://github.com/chris-landclan/jasperreports.git</connection>
-		<tag>6.17.0-landclan-11</tag>
+		<tag>6.17.0-landclan-12</tag>
 		<url>https://github.com/chris-landclan/jasperreports</url>
 	</scm>
 	<properties>

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.jasperreports</groupId>
 	<artifactId>jasperreports</artifactId>
-	<version>6.17.0-landclan-16</version>
+	<version>6.17.0-landclan-17</version>
 	<packaging>jar</packaging>
 	<name>JasperReports Library</name>
 	<description>Free Java Reporting Library</description>
@@ -49,7 +49,7 @@
 	</developers>
 	<scm>
 		<connection>scm:git:https://github.com/chris-landclan/jasperreports.git</connection>
-		<tag>6.17.0-landclan-16</tag>
+		<tag>6.17.0-landclan-17</tag>
 		<url>https://github.com/chris-landclan/jasperreports</url>
 	</scm>
 	<properties>

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.jasperreports</groupId>
 	<artifactId>jasperreports</artifactId>
-	<version>6.17.0-landclan-9</version>
+	<version>6.17.0-landclan-10</version>
 	<packaging>jar</packaging>
 	<name>JasperReports Library</name>
 	<description>Free Java Reporting Library</description>
@@ -49,7 +49,7 @@
 	</developers>
 	<scm>
 		<connection>scm:git:https://github.com/chris-landclan/jasperreports.git</connection>
-		<tag>6.17.0-landclan-9</tag>
+		<tag>6.17.0-landclan-10</tag>
 		<url>https://github.com/chris-landclan/jasperreports</url>
 	</scm>
 	<properties>

--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sf.jasperreports</groupId>
 	<artifactId>jasperreports</artifactId>
-	<version>6.17.0-landclan-19</version>
+	<version>6.17.0-landclan-20</version>
 	<packaging>jar</packaging>
 	<name>JasperReports Library</name>
 	<description>Free Java Reporting Library</description>
@@ -49,7 +49,7 @@
 	</developers>
 	<scm>
 		<connection>scm:git:https://github.com/chris-landclan/jasperreports.git</connection>
-		<tag>6.17.0-landclan-19</tag>
+		<tag>6.17.0-landclan-20</tag>
 		<url>https://github.com/chris-landclan/jasperreports</url>
 	</scm>
 	<properties>

--- a/jasperreports/src/net/sf/jasperreports/components/items/fill/FillItemData.java
+++ b/jasperreports/src/net/sf/jasperreports/components/items/fill/FillItemData.java
@@ -128,6 +128,14 @@ public abstract class FillItemData
 		
 		return evaluatedItems;
 	}
+
+	public List<Map<String, Object>> getEvaluatedItems() {
+		return evaluatedItems;
+	}
+
+	public void setEvaluatedItems(List<Map<String, Object>> value) {
+		this.evaluatedItems = value;
+	}
 	
 	/**
 	 *

--- a/jasperreports/src/net/sf/jasperreports/components/map/MapCompiler.java
+++ b/jasperreports/src/net/sf/jasperreports/components/map/MapCompiler.java
@@ -153,6 +153,13 @@ public class MapCompiler implements ComponentCompiler
 						+ evaluationGroup + " not found", map);
 			}
 		}
+
+		/* LandClan removed: To allow implicit location support by making lat/long non-mandatory.
+
+		if((map.getLatitudeExpression() == null || map.getLongitudeExpression() == null) && map.getAddressExpression() == null){
+			verifier.addBrokenRule("Missing the latitude and/or the longitude expression for the map center. Try to configure them properly, or configure the equivalent addressExpression for this map.", map);
+		}
+		*/
 		
 		String[] reqNames = new String[]{MapComponent.ITEM_PROPERTY_latitude, MapComponent.ITEM_PROPERTY_longitude};
 		List<ItemData> markerDataList = map.getMarkerDataList();

--- a/jasperreports/src/net/sf/jasperreports/components/map/MapCompiler.java
+++ b/jasperreports/src/net/sf/jasperreports/components/map/MapCompiler.java
@@ -154,10 +154,6 @@ public class MapCompiler implements ComponentCompiler
 			}
 		}
 		
-		if((map.getLatitudeExpression() == null || map.getLongitudeExpression() == null) && map.getAddressExpression() == null){
-			verifier.addBrokenRule("Missing the latitude and/or the longitude expression for the map center. Try to configure them properly, or configure the equivalent addressExpression for this map.", map);
-		}
-		
 		String[] reqNames = new String[]{MapComponent.ITEM_PROPERTY_latitude, MapComponent.ITEM_PROPERTY_longitude};
 		List<ItemData> markerDataList = map.getMarkerDataList();
 		if (markerDataList != null && markerDataList.size() > 0)

--- a/jasperreports/src/net/sf/jasperreports/components/map/MapElementImageProvider.java
+++ b/jasperreports/src/net/sf/jasperreports/components/map/MapElementImageProvider.java
@@ -65,7 +65,10 @@ public class MapElementImageProvider {
      */
     // Environmental style that shows natural features and attractions with transport icons hidden.
     public static final int ZOOM_STYLE_ENVIRONMENT = 30;
-    public static final String STYLE_ENVIRONMENT = "style=feature:poi%7Cvisibility:off&style=feature:poi.attraction%7Cvisibility:on&style=feature:poi.park%7Cvisibility:on&style=feature:transit%7Celement:labels.icon%7Cvisibility:off";
+    public static final String STYLE_ENVIRONMENT = "&style=feature:poi%7Cvisibility:off&style=feature:poi.attraction%7Cvisibility:on&style=feature:poi.park%7Cvisibility:on&style=feature:transit%7Celement:labels.icon%7Cvisibility:off";
+    // Flood style that shows natural features with transport icons hidden.
+    public static final int ZOOM_STYLE_FLOOD = 31;
+    public static final String STYLE_FLOOD = "&style=feature:poi%7Cvisibility:off&style=feature:poi.park%7Cvisibility:on&style=feature:transit%7Celement:labels.icon%7Cvisibility:off";
 
     /**
      * Shared class to abstract URL creation to allow applications to determine in advance whether the URL limit will
@@ -258,7 +261,6 @@ public class MapElementImageProvider {
         decimalFormat.setRoundingMode(RoundingMode.CEILING);
 
         if (markerList != null && !markerList.isEmpty()) {
-            landclanLog("markerList.size() = " + markerList.size());
             // Each unique marker configuration (other than lat/lon) can be passed as one parameter
             Map<MarkerProperties, List<String>> markerGroups = new HashMap<>();
 
@@ -416,6 +418,8 @@ public class MapElementImageProvider {
         switch (zoom) {
             case ZOOM_STYLE_ENVIRONMENT:
                 return STYLE_ENVIRONMENT;
+            case ZOOM_STYLE_FLOOD:
+                return STYLE_FLOOD;
             default:
                 return null;
         }

--- a/jasperreports/src/net/sf/jasperreports/components/map/MapElementImageProvider.java
+++ b/jasperreports/src/net/sf/jasperreports/components/map/MapElementImageProvider.java
@@ -57,7 +57,7 @@ public class MapElementImageProvider {
     /**
      * The character count limit for a static map URL request
      */
-    public static Integer MAX_URL_LENGTH = 8192;
+    public static final int  MAX_URL_LENGTH = 8192;
 
     /**
      * Zoom-style constants. This is a work around for the jasperreports schema not supporting map style
@@ -201,7 +201,7 @@ public class MapElementImageProvider {
                     (List<Map<String, Object>>) element.getParameterValue(MapComponent.PARAMETER_PATHS),
                     element.getWidth(), element.getHeight());
 
-            String imageLocation = buildMapImageUrl(args);
+            String imageLocation = buildMapImageUrl(args, true);
             landclanLog("Requesting renderable from URL: " + imageLocation);
             cacheRenderer = RendererUtil.getInstance(jasperReportsContext).getNonLazyRenderable(imageLocation, onErrorType);
             if (cacheRenderer != null) {
@@ -234,7 +234,7 @@ public class MapElementImageProvider {
     }
 
     @SuppressWarnings("unchecked")
-    public static String buildMapImageUrl(MapImageUrlArgs args) {
+    public static String buildMapImageUrl(MapImageUrlArgs args, boolean keepWithinMaxUrlLength) {
         Float latitude = args.getLatitude();
         latitude = latitude == null ? MapComponent.DEFAULT_LATITUDE : latitude;
 
@@ -387,6 +387,11 @@ public class MapElementImageProvider {
                 + styles;
         String params = (reqParams == null || reqParams.trim().length() == 0 ? "" : "&" + reqParams);
 
+        if (!keepWithinMaxUrlLength) {
+            // To check if all the data can be supported by the URL. Can use this response to
+            // re-structure data and potentially split the data across multiple maps.
+            return markers + currentPaths.toString() + params;
+        }
         //a static map url is limited to 8192 characters
         imageLocation += imageLocation.length() + markers.length() + currentPaths.length() + params.length() < MAX_URL_LENGTH
                 ? markers + currentPaths.toString() + params

--- a/jasperreports/src/net/sf/jasperreports/components/map/MapElementImageProvider.java
+++ b/jasperreports/src/net/sf/jasperreports/components/map/MapElementImageProvider.java
@@ -48,7 +48,7 @@ public class MapElementImageProvider
 	/**
 	 * The character count limit for a static map URL request
 	 */
-	public static Integer MAX_URL_LENGTH = 2048;
+	public static Integer MAX_URL_LENGTH = 8192;
 	
 	public static JRPrintImage getImage(JasperReportsContext jasperReportsContext, JRGenericPrintElement element) throws JRException
 	{

--- a/jasperreports/src/net/sf/jasperreports/components/map/MapElementImageProvider.java
+++ b/jasperreports/src/net/sf/jasperreports/components/map/MapElementImageProvider.java
@@ -90,26 +90,9 @@ public class MapElementImageProvider {
         }
     }
 
+    // TODO: Make a PR on the main TIBCO repo for these changes, minus the logging
+    @SuppressWarnings("unchecked")
     public static JRPrintImage getImage(JasperReportsContext jasperReportsContext, JRGenericPrintElement element) throws JRException {
-
-        Float latitude = (Float) element.getParameterValue(MapComponent.ITEM_PROPERTY_latitude);
-        latitude = latitude == null ? MapComponent.DEFAULT_LATITUDE : latitude;
-
-        Float longitude = (Float) element.getParameterValue(MapComponent.ITEM_PROPERTY_longitude);
-        longitude = longitude == null ? MapComponent.DEFAULT_LONGITUDE : longitude;
-
-        Integer zoom = (Integer) element.getParameterValue(MapComponent.PARAMETER_ZOOM);
-        zoom = zoom == null ? MapComponent.DEFAULT_ZOOM : zoom;
-
-        String mapType = (String) element.getParameterValue(MapComponent.ATTRIBUTE_MAP_TYPE);
-        String mapScale = (String) element.getParameterValue(MapComponent.ATTRIBUTE_MAP_SCALE);
-        String mapFormat = (String) element.getParameterValue(MapComponent.ATTRIBUTE_IMAGE_TYPE);
-        String reqParams = (String) element.getParameterValue(MapComponent.PARAMETER_REQ_PARAMS);
-        String markers = "";
-
-        List<Map<String, Object>> markerList = (List<Map<String, Object>>) element.getParameterValue(MapComponent.PARAMETER_MARKERS);
-        // TODO: Add the markers more efficiently so that those with matching configuration are added to the
-        //  same "markers" parameter.
 
         Renderable cacheRenderer = (Renderable) element.getParameterValue(MapComponent.PARAMETER_CACHE_RENDERER);
 
@@ -119,6 +102,27 @@ public class MapElementImageProvider {
                         : OnErrorTypeEnum.getByName((String) element.getParameterValue(MapComponent.PARAMETER_ON_ERROR_TYPE));
 
         if (cacheRenderer == null) {
+
+            // TODO: Add the markers more efficiently so that those with matching configuration are added to the
+            //  same "markers" parameter.
+
+            Float latitude = (Float) element.getParameterValue(MapComponent.ITEM_PROPERTY_latitude);
+            latitude = latitude == null ? MapComponent.DEFAULT_LATITUDE : latitude;
+
+            Float longitude = (Float) element.getParameterValue(MapComponent.ITEM_PROPERTY_longitude);
+            longitude = longitude == null ? MapComponent.DEFAULT_LONGITUDE : longitude;
+
+            Integer zoom = (Integer) element.getParameterValue(MapComponent.PARAMETER_ZOOM);
+            zoom = zoom == null ? MapComponent.DEFAULT_ZOOM : zoom;
+
+            String mapType = (String) element.getParameterValue(MapComponent.ATTRIBUTE_MAP_TYPE);
+            String mapScale = (String) element.getParameterValue(MapComponent.ATTRIBUTE_MAP_SCALE);
+            String mapFormat = (String) element.getParameterValue(MapComponent.ATTRIBUTE_IMAGE_TYPE);
+            String reqParams = (String) element.getParameterValue(MapComponent.PARAMETER_REQ_PARAMS);
+            String markers = "";
+
+            List<Map<String, Object>> markerList =
+                    (List<Map<String, Object>>) element.getParameterValue(MapComponent.PARAMETER_MARKERS);
 
             if (markerList != null && !markerList.isEmpty()) {
                 // LandClan: Added logging
@@ -132,7 +136,8 @@ public class MapElementImageProvider {
                         String color = (String) map.get(MapComponent.ITEM_PROPERTY_MARKER_color);
                         currentMarkers += color != null && color.length() > 0 ? "color:0x" + color + "%7C" : "";
                         String label = (String) map.get(MapComponent.ITEM_PROPERTY_MARKER_label);
-                        currentMarkers += label != null && label.length() > 0 ? "label:" + Character.toUpperCase(label.charAt(0)) + "%7C" : "";
+                        currentMarkers += label != null && label.length() > 0 ? "label:" +
+                                Character.toUpperCase(label.charAt(0)) + "%7C" : "";
                         String icon = map.get(MapComponent.ITEM_PROPERTY_MARKER_ICON_url) != null
                                 ? (String) map.get(MapComponent.ITEM_PROPERTY_MARKER_ICON_url)
                                 : (String) map.get(MapComponent.ITEM_PROPERTY_MARKER_icon);
@@ -217,8 +222,11 @@ public class MapElementImageProvider {
                     + element.getHeight()
                     + (mapType == null ? "" : "&maptype=" + mapType)
                     + (mapFormat == null ? "" : "&format=" + mapFormat)
-                    + (mapScale == null ? "" : "&scale=" + mapScale);
+                    + (mapScale == null ? "" : "&scale=" + mapScale)
+                    // Hide the POI markers (would be nice to have this supported upstream as a map component feature)
+                    + "&style=feature:poi%7Cvisibility:off";
             String params = (reqParams == null || reqParams.trim().length() == 0 ? "" : "&" + reqParams);
+            landclanLog("params = " + params);
 
             //a static map url is limited to 8192 characters
             imageLocation += imageLocation.length() + markers.length() + currentPaths.length() + params.length() < MAX_URL_LENGTH

--- a/jasperreports/src/net/sf/jasperreports/components/map/MapElementImageProvider.java
+++ b/jasperreports/src/net/sf/jasperreports/components/map/MapElementImageProvider.java
@@ -124,6 +124,11 @@ public class MapElementImageProvider {
             List<Map<String, Object>> markerList =
                     (List<Map<String, Object>>) element.getParameterValue(MapComponent.PARAMETER_MARKERS);
 
+            // Round to up to 5 d.p. which is approx. 1m precision. 6 d.p. is approx 10cm precision - too much info.
+            // Keeping the URL short to support more data is more important than >1m precision.
+            DecimalFormat decimalFormat = new DecimalFormat("#.#####");
+            decimalFormat.setRoundingMode(RoundingMode.CEILING);
+
             if (markerList != null && !markerList.isEmpty()) {
                 landclanLog("markerList.size() = " + markerList.size());
                 // Each unique marker configuration (other than lat/lon) can be passed as one parameter
@@ -144,8 +149,8 @@ public class MapElementImageProvider {
                         } else {
                             groupLocations = markerGroups.get(markerProperties);
                         }
-                        groupLocations.add(map.get(MapComponent.ITEM_PROPERTY_latitude) + "," +
-                                map.get(MapComponent.ITEM_PROPERTY_longitude));
+                        groupLocations.add(decimalFormat.format(map.get(MapComponent.ITEM_PROPERTY_latitude)) + "," +
+                                decimalFormat.format(map.get(MapComponent.ITEM_PROPERTY_longitude)));
                         markerGroups.put(markerProperties, groupLocations);
                     }
                 }
@@ -172,10 +177,6 @@ public class MapElementImageProvider {
             List<Map<String, Object>> pathList = (List<Map<String, Object>>) element.getParameterValue(MapComponent.PARAMETER_PATHS);
             String currentPaths = "";
             if (pathList != null && !pathList.isEmpty()) {
-                // Round to up to 5 d.p. which is approx. 1m precision. 6 d.p. is approx 10cm precision - too much info.
-                // Keeping the URL short to support more data is more important than >1m precision.
-                DecimalFormat decimalFormat = new DecimalFormat("#.#####");
-                decimalFormat.setRoundingMode(RoundingMode.CEILING);
                 for (Map<String, Object> pathMap : pathList) {
                     if (pathMap != null && !pathMap.isEmpty()) {
                         currentPaths += "&path=";

--- a/jasperreports/src/net/sf/jasperreports/components/map/MapElementImageProvider.java
+++ b/jasperreports/src/net/sf/jasperreports/components/map/MapElementImageProvider.java
@@ -24,6 +24,8 @@
 package net.sf.jasperreports.components.map;
 
 import java.awt.Color;
+import java.math.RoundingMode;
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -170,6 +172,10 @@ public class MapElementImageProvider {
             List<Map<String, Object>> pathList = (List<Map<String, Object>>) element.getParameterValue(MapComponent.PARAMETER_PATHS);
             String currentPaths = "";
             if (pathList != null && !pathList.isEmpty()) {
+                // Round to up to 5 d.p. which is approx. 1m precision. 6 d.p. is approx 10cm precision - too much info.
+                // Keeping the URL short to support more data is more important than >1m precision.
+                DecimalFormat decimalFormat = new DecimalFormat("#.#####");
+                decimalFormat.setRoundingMode(RoundingMode.CEILING);
                 for (Map<String, Object> pathMap : pathList) {
                     if (pathMap != null && !pathMap.isEmpty()) {
                         currentPaths += "&path=";
@@ -201,16 +207,16 @@ public class MapElementImageProvider {
                         if (locations != null && !locations.isEmpty()) {
                             for (int i = 0; i < locations.size(); i++) {
                                 location = locations.get(i);
-                                currentPaths += location.get(MapComponent.ITEM_PROPERTY_latitude);
+                                currentPaths += decimalFormat.format(location.get(MapComponent.ITEM_PROPERTY_latitude));
                                 currentPaths += ",";
-                                currentPaths += location.get(MapComponent.ITEM_PROPERTY_longitude);
+                                currentPaths += decimalFormat.format(location.get(MapComponent.ITEM_PROPERTY_longitude));
                                 currentPaths += i < locations.size() - 1 ? "%7C" : "";
                             }
                             if (isPolygon) {
                                 currentPaths += "%7C";
-                                currentPaths += locations.get(0).get(MapComponent.ITEM_PROPERTY_latitude);
+                                currentPaths += decimalFormat.format(locations.get(0).get(MapComponent.ITEM_PROPERTY_latitude));
                                 currentPaths += ",";
-                                currentPaths += locations.get(0).get(MapComponent.ITEM_PROPERTY_longitude);
+                                currentPaths += decimalFormat.format(locations.get(0).get(MapComponent.ITEM_PROPERTY_longitude));
                             }
                         }
                     }

--- a/jasperreports/src/net/sf/jasperreports/components/map/MapElementImageProvider.java
+++ b/jasperreports/src/net/sf/jasperreports/components/map/MapElementImageProvider.java
@@ -26,6 +26,7 @@ package net.sf.jasperreports.components.map;
 import java.awt.Color;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import net.sf.jasperreports.engine.JRException;
 import net.sf.jasperreports.engine.JRGenericPrintElement;
@@ -45,187 +46,220 @@ import org.apache.commons.logging.LogFactory;
 /**
  * @author Sanda Zaharia (shertage@users.sourceforge.net)
  */
-public class MapElementImageProvider
-{
-	// LandClan added: Logger
-	private static final Log log = LogFactory.getLog(MapElementImageProvider.class);
+public class MapElementImageProvider {
+    // LandClan added: Logger
+    private static final Log log = LogFactory.getLog(MapElementImageProvider.class);
 
-	/**
-	 * The character count limit for a static map URL request
-	 */
-	// LandClan removed:
-	// public static Integer MAX_URL_LENGTH = 2048;
-	// LandClan added: Updated to 8192 in accordance with current documentation.
-	// See https://developers.google.com/maps/documentation/maps-static/start#url-size-restriction
-	public static Integer MAX_URL_LENGTH = 8192;
-	
-	public static JRPrintImage getImage(JasperReportsContext jasperReportsContext, JRGenericPrintElement element) throws JRException
-	{
-		
-		Float latitude = (Float)element.getParameterValue(MapComponent.ITEM_PROPERTY_latitude);
-		latitude = latitude == null ? MapComponent.DEFAULT_LATITUDE : latitude;
+    /**
+     * The character count limit for a static map URL request
+     */
+    // LandClan removed:
+    // public static Integer MAX_URL_LENGTH = 2048;
+    // LandClan added: Updated to 8192 in accordance with current documentation.
+    // See https://developers.google.com/maps/documentation/maps-static/start#url-size-restriction
+    public static Integer MAX_URL_LENGTH = 8192;
 
-		Float longitude = (Float)element.getParameterValue(MapComponent.ITEM_PROPERTY_longitude);
-		longitude = longitude == null ? MapComponent.DEFAULT_LONGITUDE : longitude;
-		
-		Integer zoom = (Integer)element.getParameterValue(MapComponent.PARAMETER_ZOOM);
-		zoom = zoom == null ? MapComponent.DEFAULT_ZOOM : zoom;
+    /**
+     * Local utility to facilitate de-duplication of repeated marker configurations in URL
+     */
+    private static class MarkerProperties {
+        private String size;
+        private String color;
+        private String label;
+        private String icon;
 
-		String mapType = (String)element.getParameterValue(MapComponent.ATTRIBUTE_MAP_TYPE);
-		String mapScale = (String)element.getParameterValue(MapComponent.ATTRIBUTE_MAP_SCALE);
-		String mapFormat = (String)element.getParameterValue(MapComponent.ATTRIBUTE_IMAGE_TYPE);
-		String reqParams = (String)element.getParameterValue(MapComponent.PARAMETER_REQ_PARAMS);
-		String markers ="";
-		
-		List<Map<String,Object>> markerList = (List<Map<String,Object>>)element.getParameterValue(MapComponent.PARAMETER_MARKERS);
-		if(markerList != null && !markerList.isEmpty())
-		{
-			String currentMarkers = "";
-			for(Map<String,Object> map : markerList)
-			{
-				if(map != null && !map.isEmpty())
-				{
-					currentMarkers = "&markers=";
-					String size = (String)map.get(MapComponent.ITEM_PROPERTY_MARKER_size);
-					currentMarkers += size != null && size.length() > 0 ? "size:" + size + "%7C" : "";
-					String color = (String)map.get(MapComponent.ITEM_PROPERTY_MARKER_color);
-					currentMarkers += color != null && color.length() > 0 ? "color:0x" + color + "%7C" : "";
-					String label = (String)map.get(MapComponent.ITEM_PROPERTY_MARKER_label);
-					currentMarkers += label != null && label.length() > 0 ? "label:" + Character.toUpperCase(label.charAt(0)) + "%7C" : "";
-					String icon = map.get(MapComponent.ITEM_PROPERTY_MARKER_ICON_url) != null 
-							? (String)map.get(MapComponent.ITEM_PROPERTY_MARKER_ICON_url) 
-							: (String)map.get(MapComponent.ITEM_PROPERTY_MARKER_icon);
-					if(icon != null && icon.length() > 0)
-					{
-						currentMarkers +="icon:" + icon + "%7C";
-					}
-					currentMarkers +=map.get(MapComponent.ITEM_PROPERTY_latitude);
-					currentMarkers +=",";
-					currentMarkers +=map.get(MapComponent.ITEM_PROPERTY_longitude);
-					markers += currentMarkers;
-				}
-			}
-		}
-		
-		List<Map<String,Object>> pathList = (List<Map<String,Object>>)element.getParameterValue(MapComponent.PARAMETER_PATHS);
-		String currentPaths = "";
-		if(pathList != null && !pathList.isEmpty())
-		{
-			for(Map<String,Object> pathMap : pathList)
-			{
-				if(pathMap != null && !pathMap.isEmpty())
-				{
-					currentPaths += "&path=";
-					String color = (String)pathMap.get(MapComponent.ITEM_PROPERTY_STYLE_strokeColor);
-					if(color != null && color.length() > 0){
-						//adding opacity to color
-						color = JRColorUtil.getColorHexa(JRColorUtil.getColor(color, Color.BLACK));
-						color += pathMap.get(MapComponent.ITEM_PROPERTY_STYLE_strokeOpacity) == null || pathMap.get(MapComponent.ITEM_PROPERTY_STYLE_strokeOpacity).toString().length() == 0
-								? "ff"
-								: Integer.toHexString((int) (255 * Double.valueOf(pathMap.get(MapComponent.ITEM_PROPERTY_STYLE_strokeOpacity).toString())));
-					}
-					currentPaths += color != null && color.length() > 0 ? "color:0x" + color.toLowerCase() + "%7C" : "";
-					Boolean isPolygon = pathMap.get(MapComponent.ITEM_PROPERTY_STYLE_isPolygon) == null ? false : Boolean.valueOf(pathMap.get(MapComponent.ITEM_PROPERTY_STYLE_isPolygon).toString());
-					if(isPolygon){
-						String fillColor = (String)pathMap.get(MapComponent.ITEM_PROPERTY_STYLE_fillColor);
-						if(fillColor != null && fillColor.length() > 0){
-							//adding opacity to fill color
-							fillColor = JRColorUtil.getColorHexa(JRColorUtil.getColor(fillColor, Color.WHITE));
-							fillColor += pathMap.get(MapComponent.ITEM_PROPERTY_STYLE_fillOpacity) == null || pathMap.get(MapComponent.ITEM_PROPERTY_STYLE_fillOpacity).toString().length() == 0
-								? "00"
-								: Integer.toHexString((int) (256 * Double.valueOf(pathMap.get(MapComponent.ITEM_PROPERTY_STYLE_fillOpacity).toString())));
-						}
-						currentPaths += fillColor != null && fillColor.length() > 0 ? "fillcolor:0x" + fillColor.toLowerCase() + "%7C" : "";
-					}
-					String weight = pathMap.get(MapComponent.ITEM_PROPERTY_STYLE_strokeWeight) == null ? null : pathMap.get(MapComponent.ITEM_PROPERTY_STYLE_strokeWeight).toString();
-					currentPaths += weight != null && weight.length() > 0 ? "weight:" + Integer.valueOf(weight) + "%7C" : "";
-					List<Map<String,Object>> locations = (List<Map<String,Object>>)pathMap.get(MapComponent.PARAMETER_PATH_LOCATIONS);
-					Map<String,Object> location = null;
-					if(locations != null && !locations.isEmpty()) {
-						for(int i = 0; i < locations.size(); i++) {
-							location = locations.get(i);
-							currentPaths += location.get(MapComponent.ITEM_PROPERTY_latitude);
-							currentPaths += ",";
-							currentPaths += location.get(MapComponent.ITEM_PROPERTY_longitude);
-							currentPaths += i < locations.size() - 1 ? "%7C":"";
-						}
-						if(isPolygon){
-							currentPaths += "%7C";
-							currentPaths += locations.get(0).get(MapComponent.ITEM_PROPERTY_latitude);
-							currentPaths += ",";
-							currentPaths += locations.get(0).get(MapComponent.ITEM_PROPERTY_longitude);
-						}
-					}
-				}
-			}
-		}
+        public MarkerProperties(String size, String color, String label, String icon) {
+            this.size = size;
+            this.color = color;
+            this.label = label;
+            this.icon = icon;
+        }
 
-		// LandClan: Updated - added logic to support implicit positioning
-		String imageLocation = "https://maps.googleapis.com/maps/api/staticmap?";
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            MarkerProperties that = (MarkerProperties) o;
+            return Objects.equals(size, that.size) && Objects.equals(color, that.color) &&
+                    Objects.equals(label, that.label) && Objects.equals(icon, that.icon);
+        }
 
-		if (Math.abs(latitude) > 0.0001 && Math.abs(longitude) > 0.0001) {
-			// Use normal positioning:
-			imageLocation += "center="
-					+ latitude
-					+ ","
-					+ longitude
-					+ "&zoom="
-					+ zoom
-					+ "&";
-		}
+        @Override
+        public int hashCode() {
+            return Objects.hash(size, color, label, icon);
+        }
+    }
 
-		imageLocation += "size="
-			+ element.getWidth() 
-			+ "x" 
-			+ element.getHeight()
-			+ (mapType == null ? "" : "&maptype=" + mapType)
-			+ (mapFormat == null ? "" : "&format=" + mapFormat)
-			+ (mapScale == null ? "" : "&scale=" + mapScale);
-		String params = (reqParams == null || reqParams.trim().length() == 0 ? "" : "&" + reqParams);
+    public static JRPrintImage getImage(JasperReportsContext jasperReportsContext, JRGenericPrintElement element) throws JRException {
 
-		//a static map url is limited to 8192 characters
-		imageLocation += imageLocation.length() + markers.length() + currentPaths.length() + params.length() < MAX_URL_LENGTH 
-				? markers + currentPaths + params 
-				: imageLocation.length() + markers.length() + params.length() < MAX_URL_LENGTH ? markers + params : params;
-		JRBasePrintImage printImage = new JRBasePrintImage(element.getDefaultStyleProvider());
+        Float latitude = (Float) element.getParameterValue(MapComponent.ITEM_PROPERTY_latitude);
+        latitude = latitude == null ? MapComponent.DEFAULT_LATITUDE : latitude;
 
-		printImage.setUUID(element.getUUID());
-		printImage.setX(element.getX());
-		printImage.setY(element.getY());
-		printImage.setWidth(element.getWidth());
-		printImage.setHeight(element.getHeight());
-		printImage.setStyle(element.getStyle());
-		printImage.setMode(element.getModeValue());
-		printImage.setBackcolor(element.getBackcolor());
-		printImage.setForecolor(element.getForecolor());
-		
-		//FIXMEMAP there are no scale image and alignment attributes defined for the map element
-		printImage.setScaleImage(ScaleImageEnum.RETAIN_SHAPE);
-		printImage.setHorizontalImageAlign(HorizontalImageAlignEnum.LEFT);
-		printImage.setVerticalImageAlign(VerticalImageAlignEnum.TOP);
-		
-		OnErrorTypeEnum onErrorType = 
-			element.getParameterValue(MapComponent.PARAMETER_ON_ERROR_TYPE) == null 
-			? MapComponent.DEFAULT_ON_ERROR_TYPE  
-			: OnErrorTypeEnum.getByName((String)element.getParameterValue(MapComponent.PARAMETER_ON_ERROR_TYPE));
-		printImage.setOnErrorType(onErrorType);
-		
-		Renderable cacheRenderer = (Renderable)element.getParameterValue(MapComponent.PARAMETER_CACHE_RENDERER);
+        Float longitude = (Float) element.getParameterValue(MapComponent.ITEM_PROPERTY_longitude);
+        longitude = longitude == null ? MapComponent.DEFAULT_LONGITUDE : longitude;
 
-		if (cacheRenderer == null)
-		{
-			// LandClan added: logging of URL
-			log.info("Requesting renderable from URL: " + imageLocation);
-			cacheRenderer = RendererUtil.getInstance(jasperReportsContext).getNonLazyRenderable(imageLocation, onErrorType);
-			if (cacheRenderer != null)
-			{
-				element.setParameterValue(MapComponent.PARAMETER_CACHE_RENDERER, cacheRenderer);
-			}
-		}
+        Integer zoom = (Integer) element.getParameterValue(MapComponent.PARAMETER_ZOOM);
+        zoom = zoom == null ? MapComponent.DEFAULT_ZOOM : zoom;
 
-		printImage.setRenderer(cacheRenderer);
-		
-		return printImage;
-	}
-	
+        String mapType = (String) element.getParameterValue(MapComponent.ATTRIBUTE_MAP_TYPE);
+        String mapScale = (String) element.getParameterValue(MapComponent.ATTRIBUTE_MAP_SCALE);
+        String mapFormat = (String) element.getParameterValue(MapComponent.ATTRIBUTE_IMAGE_TYPE);
+        String reqParams = (String) element.getParameterValue(MapComponent.PARAMETER_REQ_PARAMS);
+        String markers = "";
+
+        List<Map<String, Object>> markerList = (List<Map<String, Object>>) element.getParameterValue(MapComponent.PARAMETER_MARKERS);
+        // TODO: Add the markers more efficiently so that those with matching configuration are added to the
+        //  same "markers" parameter.
+
+        Renderable cacheRenderer = (Renderable) element.getParameterValue(MapComponent.PARAMETER_CACHE_RENDERER);
+
+        OnErrorTypeEnum onErrorType =
+                element.getParameterValue(MapComponent.PARAMETER_ON_ERROR_TYPE) == null
+                        ? MapComponent.DEFAULT_ON_ERROR_TYPE
+                        : OnErrorTypeEnum.getByName((String) element.getParameterValue(MapComponent.PARAMETER_ON_ERROR_TYPE));
+
+        if (cacheRenderer == null) {
+
+            if (markerList != null && !markerList.isEmpty()) {
+                // LandClan: Added logging
+                landclanLog("markerList.size() = " + markerList.size());
+                String currentMarkers = "";
+                for (Map<String, Object> map : markerList) {
+                    if (map != null && !map.isEmpty()) {
+                        currentMarkers = "&markers=";
+                        String size = (String) map.get(MapComponent.ITEM_PROPERTY_MARKER_size);
+                        currentMarkers += size != null && size.length() > 0 ? "size:" + size + "%7C" : "";
+                        String color = (String) map.get(MapComponent.ITEM_PROPERTY_MARKER_color);
+                        currentMarkers += color != null && color.length() > 0 ? "color:0x" + color + "%7C" : "";
+                        String label = (String) map.get(MapComponent.ITEM_PROPERTY_MARKER_label);
+                        currentMarkers += label != null && label.length() > 0 ? "label:" + Character.toUpperCase(label.charAt(0)) + "%7C" : "";
+                        String icon = map.get(MapComponent.ITEM_PROPERTY_MARKER_ICON_url) != null
+                                ? (String) map.get(MapComponent.ITEM_PROPERTY_MARKER_ICON_url)
+                                : (String) map.get(MapComponent.ITEM_PROPERTY_MARKER_icon);
+                        if (icon != null && icon.length() > 0) {
+                            currentMarkers += "icon:" + icon + "%7C";
+                        }
+                        currentMarkers += map.get(MapComponent.ITEM_PROPERTY_latitude);
+                        currentMarkers += ",";
+                        currentMarkers += map.get(MapComponent.ITEM_PROPERTY_longitude);
+                        markers += currentMarkers;
+                    }
+                }
+            }
+
+            List<Map<String, Object>> pathList = (List<Map<String, Object>>) element.getParameterValue(MapComponent.PARAMETER_PATHS);
+            String currentPaths = "";
+            if (pathList != null && !pathList.isEmpty()) {
+                for (Map<String, Object> pathMap : pathList) {
+                    if (pathMap != null && !pathMap.isEmpty()) {
+                        currentPaths += "&path=";
+                        String color = (String) pathMap.get(MapComponent.ITEM_PROPERTY_STYLE_strokeColor);
+                        if (color != null && color.length() > 0) {
+                            //adding opacity to color
+                            color = JRColorUtil.getColorHexa(JRColorUtil.getColor(color, Color.BLACK));
+                            color += pathMap.get(MapComponent.ITEM_PROPERTY_STYLE_strokeOpacity) == null || pathMap.get(MapComponent.ITEM_PROPERTY_STYLE_strokeOpacity).toString().length() == 0
+                                    ? "ff"
+                                    : Integer.toHexString((int) (255 * Double.valueOf(pathMap.get(MapComponent.ITEM_PROPERTY_STYLE_strokeOpacity).toString())));
+                        }
+                        currentPaths += color != null && color.length() > 0 ? "color:0x" + color.toLowerCase() + "%7C" : "";
+                        Boolean isPolygon = pathMap.get(MapComponent.ITEM_PROPERTY_STYLE_isPolygon) == null ? false : Boolean.valueOf(pathMap.get(MapComponent.ITEM_PROPERTY_STYLE_isPolygon).toString());
+                        if (isPolygon) {
+                            String fillColor = (String) pathMap.get(MapComponent.ITEM_PROPERTY_STYLE_fillColor);
+                            if (fillColor != null && fillColor.length() > 0) {
+                                //adding opacity to fill color
+                                fillColor = JRColorUtil.getColorHexa(JRColorUtil.getColor(fillColor, Color.WHITE));
+                                fillColor += pathMap.get(MapComponent.ITEM_PROPERTY_STYLE_fillOpacity) == null || pathMap.get(MapComponent.ITEM_PROPERTY_STYLE_fillOpacity).toString().length() == 0
+                                        ? "00"
+                                        : Integer.toHexString((int) (256 * Double.valueOf(pathMap.get(MapComponent.ITEM_PROPERTY_STYLE_fillOpacity).toString())));
+                            }
+                            currentPaths += fillColor != null && fillColor.length() > 0 ? "fillcolor:0x" + fillColor.toLowerCase() + "%7C" : "";
+                        }
+                        String weight = pathMap.get(MapComponent.ITEM_PROPERTY_STYLE_strokeWeight) == null ? null : pathMap.get(MapComponent.ITEM_PROPERTY_STYLE_strokeWeight).toString();
+                        currentPaths += weight != null && weight.length() > 0 ? "weight:" + Integer.valueOf(weight) + "%7C" : "";
+                        List<Map<String, Object>> locations = (List<Map<String, Object>>) pathMap.get(MapComponent.PARAMETER_PATH_LOCATIONS);
+                        Map<String, Object> location = null;
+                        if (locations != null && !locations.isEmpty()) {
+                            for (int i = 0; i < locations.size(); i++) {
+                                location = locations.get(i);
+                                currentPaths += location.get(MapComponent.ITEM_PROPERTY_latitude);
+                                currentPaths += ",";
+                                currentPaths += location.get(MapComponent.ITEM_PROPERTY_longitude);
+                                currentPaths += i < locations.size() - 1 ? "%7C" : "";
+                            }
+                            if (isPolygon) {
+                                currentPaths += "%7C";
+                                currentPaths += locations.get(0).get(MapComponent.ITEM_PROPERTY_latitude);
+                                currentPaths += ",";
+                                currentPaths += locations.get(0).get(MapComponent.ITEM_PROPERTY_longitude);
+                            }
+                        }
+                    }
+                }
+            }
+
+            // LandClan: Updated - added logic to support implicit positioning
+            String imageLocation = "https://maps.googleapis.com/maps/api/staticmap?";
+
+            if (Math.abs(latitude) > 0.0001 && Math.abs(longitude) > 0.0001) {
+                // Use normal positioning:
+                imageLocation += "center="
+                        + latitude
+                        + ","
+                        + longitude
+                        + "&zoom="
+                        + zoom
+                        + "&";
+            }
+
+            imageLocation += "size="
+                    + element.getWidth()
+                    + "x"
+                    + element.getHeight()
+                    + (mapType == null ? "" : "&maptype=" + mapType)
+                    + (mapFormat == null ? "" : "&format=" + mapFormat)
+                    + (mapScale == null ? "" : "&scale=" + mapScale);
+            String params = (reqParams == null || reqParams.trim().length() == 0 ? "" : "&" + reqParams);
+
+            //a static map url is limited to 8192 characters
+            imageLocation += imageLocation.length() + markers.length() + currentPaths.length() + params.length() < MAX_URL_LENGTH
+                    ? markers + currentPaths + params
+                    : imageLocation.length() + markers.length() + params.length() < MAX_URL_LENGTH ? markers + params : params;
+
+            // LandClan added: logging of URL
+            landclanLog("Requesting renderable from URL: " + imageLocation);
+            cacheRenderer = RendererUtil.getInstance(jasperReportsContext).getNonLazyRenderable(imageLocation, onErrorType);
+            if (cacheRenderer != null) {
+                element.setParameterValue(MapComponent.PARAMETER_CACHE_RENDERER, cacheRenderer);
+            }
+        }
+
+        JRBasePrintImage printImage = new JRBasePrintImage(element.getDefaultStyleProvider());
+
+        printImage.setUUID(element.getUUID());
+        printImage.setX(element.getX());
+        printImage.setY(element.getY());
+        printImage.setWidth(element.getWidth());
+        printImage.setHeight(element.getHeight());
+        printImage.setStyle(element.getStyle());
+        printImage.setMode(element.getModeValue());
+        printImage.setBackcolor(element.getBackcolor());
+        printImage.setForecolor(element.getForecolor());
+
+        //FIXMEMAP there are no scale image and alignment attributes defined for the map element
+        printImage.setScaleImage(ScaleImageEnum.RETAIN_SHAPE);
+        printImage.setHorizontalImageAlign(HorizontalImageAlignEnum.LEFT);
+        printImage.setVerticalImageAlign(VerticalImageAlignEnum.TOP);
+
+        printImage.setOnErrorType(onErrorType);
+
+        printImage.setRenderer(cacheRenderer);
+
+        return printImage;
+    }
+
+    // LandClan added logging with Thread identification
+    private static void landclanLog(String msg) {
+        log.info("[" + Thread.currentThread().getName() + "] " + msg);
+    }
+
 }

--- a/jasperreports/src/net/sf/jasperreports/components/map/PolylineEncoder.java
+++ b/jasperreports/src/net/sf/jasperreports/components/map/PolylineEncoder.java
@@ -1,0 +1,116 @@
+package net.sf.jasperreports.components.map;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+/**
+ * Encodes paths into Google static maps API encoded polylines to facilitate shorter URLs.
+ * See https://developers.google.com/maps/documentation/utilities/polylinealgorithm.
+ * Based on the C# implementation at https://gist.github.com/shinyzhu/4617989
+ */
+public class PolylineEncoder {
+
+    private static class LatLng implements Cloneable {
+        double lat;
+        double lng;
+
+        LatLng(double lat, double lng) {
+            this.lat = lat;
+            this.lng = lng;
+        }
+
+        @Override
+        public LatLng clone() {
+            try {
+                return (LatLng) super.clone();
+            } catch (CloneNotSupportedException e) {
+                throw new AssertionError();
+            }
+        }
+    }
+
+    private final List<LatLng> locations;
+
+    public PolylineEncoder(List<Map<String, Object>> locations, boolean isPolygon) {
+        this.locations = transformLocations(locations, isPolygon);
+    }
+
+    public String encode() {
+        StringBuilder str = new StringBuilder();
+
+        Consumer<Integer> encodeDiff = (diff -> {
+            int shifted = diff << 1;
+            if (diff < 0) {
+                shifted = ~shifted;
+            }
+            int rem = shifted;
+
+            while (rem >= 0x20) {
+                str.append((char) ((0x20 | (rem & 0x1f)) + 63));
+
+                rem >>= 5;
+            }
+
+            str.append((char) (rem + 63));
+        });
+
+        int lastLat = 0;
+        int lastLng = 0;
+
+        for (LatLng location : locations) {
+            int lat = (int) Math.round(location.lat * 1E5);
+            int lng = (int) Math.round(location.lng * 1E5);
+
+            encodeDiff.accept(lat - lastLat);
+            encodeDiff.accept(lng - lastLng);
+
+            lastLat = lat;
+            lastLng = lng;
+        }
+
+        return str.toString();
+    }
+
+    private static List<LatLng> transformLocations(List<Map<String, Object>> locations, boolean isPolygon) {
+
+        List<LatLng> latLngs = new ArrayList<>();
+        if (locations == null || locations.isEmpty()) {
+            return latLngs;
+        }
+
+        Object sample = locations.get(0).get(MapComponent.ITEM_PROPERTY_latitude);
+        if (sample instanceof Double) {
+            latLngs = locations.stream().map(PolylineEncoder::transformLocationFromDouble).collect(Collectors.toList());
+        } else if (sample instanceof Float) {
+            latLngs = locations.stream().map(PolylineEncoder::transformLocationFromFloat).collect(Collectors.toList());
+        } else if (sample instanceof String) {
+            latLngs = locations.stream().map(PolylineEncoder::transformLocationFromString).collect(Collectors.toList());
+        } else {
+            throw new RuntimeException("Unhandled type for location coordinates: " + sample.getClass().getName());
+        }
+
+        if (isPolygon && !latLngs.isEmpty()) {
+            latLngs.add(latLngs.get(0).clone());
+        }
+
+        return latLngs;
+    }
+
+    private static LatLng transformLocationFromDouble(Map<String, Object> location) {
+        return new LatLng((Double) location.get(MapComponent.ITEM_PROPERTY_latitude),
+                (Double) location.get(MapComponent.ITEM_PROPERTY_longitude));
+    }
+
+    private static LatLng transformLocationFromFloat(Map<String, Object> location) {
+        return new LatLng(Double.valueOf((Float) location.get(MapComponent.ITEM_PROPERTY_latitude)),
+                Double.valueOf((Float) location.get(MapComponent.ITEM_PROPERTY_longitude)));
+    }
+
+    private static LatLng transformLocationFromString(Map<String, Object> location) {
+        return new LatLng(Double.parseDouble((String) location.get(MapComponent.ITEM_PROPERTY_latitude)),
+                Double.parseDouble((String) location.get(MapComponent.ITEM_PROPERTY_longitude)));
+    }
+}

--- a/jasperreports/src/net/sf/jasperreports/components/map/fill/FillPlaceItem.java
+++ b/jasperreports/src/net/sf/jasperreports/components/map/fill/FillPlaceItem.java
@@ -124,14 +124,15 @@ public class FillPlaceItem extends FillItem
 					result.put(MapComponent.ITEM_PROPERTY_latitude, coords[0]);
 					result.put(MapComponent.ITEM_PROPERTY_longitude, coords[1]);
 					result.remove(MapComponent.ITEM_PROPERTY_address);
-				} else {
+				} /* LandClan removed: To allow implicit location support by making lat/long non-mandatory.
+				else {
 					throw 
 						new JRException(
 							MapFillComponent.EXCEPTION_MESSAGE_KEY_INVALID_ADDRESS_COORDINATES,  
 							new Object[]{coords[0], coords[1]} 
 							);
-				}
-			}
+				}*/
+			}/* LandClan removed: To allow implicit location support by making lat/long non-mandatory.
 			else 
 			{
 				throw 
@@ -139,7 +140,7 @@ public class FillPlaceItem extends FillItem
 						EXCEPTION_MESSAGE_KEY_MISSING_COORDINATES,  
 						new Object[]{fLatitude == null ? MapComponent.ITEM_PROPERTY_latitude : MapComponent.ITEM_PROPERTY_longitude}
 						);
-			}
+			}*/
 		}
 	}
 	

--- a/jasperreports/src/net/sf/jasperreports/components/map/fill/MapFillComponent.java
+++ b/jasperreports/src/net/sf/jasperreports/components/map/fill/MapFillComponent.java
@@ -226,6 +226,14 @@ public class MapFillComponent extends BaseFillComponent implements FillContextPr
 		}
 		
 		if(pathDataList != null) {
+			if (pathDataList.size() == 1 && pathDataList.get(0).getEvaluatedItems() != null) {
+				// LandClan bug fix: Paths were accumulating with each dataset row since there is one MapFillComponent
+				// for the entire report. Each successive dataset entry was accumulating its paths on top of all
+				// preceding dataset entries' paths, so by the time 3 maps for 3 separate entries had been rendered,
+				// say, there was 1 path on the first map, 2 paths on the second (1 + 2) and 3 paths on the third
+				// (1 + 2 + 3) etc, all connected as one mega path.
+				pathDataList.get(0).setEvaluatedItems(null);
+			}
 			addPathStyles(evaluation);
 			paths = new ArrayList<Map<String,Object>>();
 			Map<String, Map<String,Object>> pathIds = new HashMap<String,Map<String,Object>>();

--- a/jasperreports/src/net/sf/jasperreports/components/map/fill/MapFillComponent.java
+++ b/jasperreports/src/net/sf/jasperreports/components/map/fill/MapFillComponent.java
@@ -183,13 +183,14 @@ public class MapFillComponent extends BaseFillComponent implements FillContextPr
 			if(coords != null && coords[0] != null && coords[1] != null){
 				latitude = coords[0];
 				longitude = coords[1];
-			} else {
+			} /* LandClan removed: To allow implicit location support by making lat/long non-mandatory.
+			else {
 				throw 
 					new JRException(
 						EXCEPTION_MESSAGE_KEY_INVALID_ADDRESS_COORDINATES,  
 						new Object[]{MapComponent.ITEM_PROPERTY_latitude, MapComponent.ITEM_PROPERTY_longitude} 
 						);
-			}
+			}*/
 		}
 		zoom = (Integer)fillContext.evaluate(mapComponent.getZoomExpression(), evaluation);
 		zoom = zoom == null ? MapComponent.DEFAULT_ZOOM : zoom;

--- a/jasperreports/src/net/sf/jasperreports/util/PreviewParamsProcessor.java
+++ b/jasperreports/src/net/sf/jasperreports/util/PreviewParamsProcessor.java
@@ -1,0 +1,41 @@
+package net.sf.jasperreports.util;
+
+import java.util.Map;
+
+import net.sf.jasperreports.engine.JRDefaultScriptlet;
+import net.sf.jasperreports.engine.JRScriptletException;
+import net.sf.jasperreports.engine.fill.JRFillParameter;
+
+public class PreviewParamsProcessor extends JRDefaultScriptlet {
+
+    private static final String PREVIEW_PARAMS_FIELD_NAME = "previewParams";
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void afterReportInit() throws JRScriptletException {
+        super.afterReportInit();
+
+        Map<String, Object> previewParams;
+
+        try {
+            previewParams = (Map<String, Object>) getFieldValue(PREVIEW_PARAMS_FIELD_NAME);
+        } catch (ClassCastException e) {
+            throw new RuntimeException(
+                    "Unable to cast field " + PREVIEW_PARAMS_FIELD_NAME + " as Map<String, Object>", e);
+        }
+
+        if (previewParams != null) {
+            loadPreviewParams(previewParams);
+        }
+    }
+
+    private void loadPreviewParams(Map<String, Object> previewParams) {
+
+        for (Map.Entry<String, JRFillParameter> entry : parametersMap.entrySet()) {
+            if (!previewParams.containsKey(entry.getKey())) {
+                continue;
+            }
+            entry.getValue().setValue(previewParams.get(entry.getKey()));
+        }
+    }
+}

--- a/jasperreports/src/net/sf/jasperreports/util/ReferenceCreator.java
+++ b/jasperreports/src/net/sf/jasperreports/util/ReferenceCreator.java
@@ -6,8 +6,10 @@ import net.sf.jasperreports.engine.data.JRMapCollectionDataSource;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * This class is used to gather reference keys and their associated incremental reference numbers during report fill
@@ -24,20 +26,22 @@ public class ReferenceCreator {
     private int currentReferenceNumber = 1;
 
     private final List<Map<String, String>> references = new ArrayList<>();
+    private final Set<String> keysAdded = new HashSet<>();
 
     /**
      * Returns the reference number for the given key for use in assigning a reference number to a super-script text
      * field. Must be rendered at Report time or at least after the given reference key has been added.
      * @param referenceKey
      * @return
+     * @throws Exception If the given key is not found (ensures robust report configuration).
      */
-    public String getReferenceNumberForKey(String referenceKey) {
+    public String getReferenceNumberForKey(String referenceKey) throws Exception {
         for (Map<String, String> reference : this.references) {
-            if(referenceKey.equals(reference.get(REFERENCE_KEY))) {
+            if (referenceKey.equals(reference.get(REFERENCE_KEY))) {
                 return reference.get(REFERENCE_NUMBER);
             }
         }
-        return null;
+        throw new Exception("Reference key \"" + referenceKey + "\" not found!");
     }
 
     /**
@@ -57,9 +61,15 @@ public class ReferenceCreator {
      * @param referenceText
      * @param referenceKey
      * @return The reference key.
+     * @throws Exception If text has already been added for the given key (ensures robust report configuration).
      */
-    public String addReferenceTextForKey(String referenceText, String referenceKey) {
-        references.add(createReferenceEntry(referenceText, referenceKey));
+    public String addReferenceTextForKey(String referenceText, String referenceKey) throws Exception {
+        if (!keysAdded.contains(referenceKey)) {
+            references.add(createReferenceEntry(referenceText, referenceKey));
+            keysAdded.add(referenceKey);
+        } else {
+            throw new Exception("Reference text was already added for key \"" + referenceKey + "\"!");
+        }
         return referenceKey;
     }
 

--- a/jasperreports/src/net/sf/jasperreports/util/ReferenceCreator.java
+++ b/jasperreports/src/net/sf/jasperreports/util/ReferenceCreator.java
@@ -45,6 +45,14 @@ public class ReferenceCreator {
     }
 
     /**
+     * Whether there are any references. Can be used to determine whether to display a references detail section.
+     * @return
+     */
+    public boolean hasReferences() {
+        return !references.isEmpty();
+    }
+
+    /**
      * Returns a {@code JRDataSource} for use as a datasource expression. The datasource contains all the reference
      * entries that have been collected for use in creating a list of references at the end of the report or report
      * section.

--- a/jasperreports/src/net/sf/jasperreports/util/ReferenceCreator.java
+++ b/jasperreports/src/net/sf/jasperreports/util/ReferenceCreator.java
@@ -185,9 +185,12 @@ public class ReferenceCreator {
             for (Map<String, String> refEntry : references) {
                 if (refEntry.get(REFERENCE_KEY).equals(referenceKey)) {
                     String currentText = refEntry.get(REFERENCE_TEXT);
-                    refEntry.put(REFERENCE_TEXT,
-                            String.join("\n", prependAdditional ? referenceText : currentText,
-                                    prependAdditional ? currentText : referenceText));
+                    // If Detail Split Type == "Prevent" then we get double calls, hence the need to check that the
+                    // currentText doesn't already contain the reference Text.
+                    if (!currentText.contains(referenceText)) {
+                        refEntry.put(REFERENCE_TEXT, String.join("\n", prependAdditional ? referenceText : currentText,
+                                prependAdditional ? currentText : referenceText));
+                    }
                     return referenceKey;
                 }
             }

--- a/jasperreports/src/net/sf/jasperreports/util/ReferenceCreator.java
+++ b/jasperreports/src/net/sf/jasperreports/util/ReferenceCreator.java
@@ -1,0 +1,73 @@
+package net.sf.jasperreports.util;
+
+import net.sf.jasperreports.engine.JRRewindableDataSource;
+import net.sf.jasperreports.engine.data.JRMapCollectionDataSource;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class is used to gather reference keys and their associated incremental reference numbers during report fill
+ * time. Each reference number is associated to a String key. During collection, key/number pairs are added and the next
+ * number is incremented. When finished, the reference data are returned as a JRDataSource or by direct retrieval by
+ * reference key.
+ */
+public class ReferenceCreator {
+
+    private static final String REFERENCE_KEY = "refKey";
+    private static final String REFERENCE_TEXT = "refText";
+    private static final String REFERENCE_NUMBER = "refNumber";
+
+    private int currentReferenceNumber = 1;
+
+    private final List<Map<String, String>> references = new ArrayList<>();
+
+    /**
+     * Returns the reference number for the given key for use in assigning a reference number to a super-script text
+     * field. Must be rendered at Report time or at least after the given reference key has been added.
+     * @param referenceKey
+     * @return
+     */
+    public String getReferenceNumberForKey(String referenceKey) {
+        for (Map<String, String> reference : this.references) {
+            if(referenceKey.equals(reference.get(REFERENCE_KEY))) {
+                return reference.get(REFERENCE_NUMBER);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns a {@code JRDataSource} for use as a datasource expression. The datasource contains all the reference
+     * entries that have been collected for use in creating a list of references at the end of the report or report
+     * section.
+     * @return
+     */
+    public JRRewindableDataSource getDataSource() {
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        Collection<Map<String, ?>> resultCollection = (Collection) references;
+        return new JRMapCollectionDataSource(resultCollection);
+    }
+
+    /**
+     * Adds the reference text for the given reference key.
+     * @param referenceText
+     * @param referenceKey
+     * @return The reference key.
+     */
+    public String addReferenceTextForKey(String referenceText, String referenceKey) {
+        references.add(createReferenceEntry(referenceText, referenceKey));
+        return referenceKey;
+    }
+
+    private Map<String, String> createReferenceEntry(String referenceText, String referenceKey) {
+        Map<String, String> refEntry = new HashMap<>();
+        refEntry.put(REFERENCE_KEY, referenceKey);
+        refEntry.put(REFERENCE_TEXT, referenceText);
+        refEntry.put(REFERENCE_NUMBER, String.valueOf(currentReferenceNumber++));
+        return refEntry;
+    }
+}

--- a/jasperreports/src/net/sf/jasperreports/util/TocCreator.java
+++ b/jasperreports/src/net/sf/jasperreports/util/TocCreator.java
@@ -1,0 +1,50 @@
+package net.sf.jasperreports.util;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class is used to gather page numbers during report fill time. Each page number is associated to a String key.
+ * During collection, key/page number pairs are added. When finished, the TOC data are returned as a JRDataSource.
+ */
+public class TocCreator {
+
+    private static final String TOC_KEY = "tocKey";
+    private static final String PAGE_NUMBER = "pageNumber";
+
+    private final List<Map<String, Object>> tocEntries = new ArrayList<>();
+
+    /**
+     * Returns the page number for the given key.
+     * @param tocKey
+     * @return
+     */
+    public Integer getPageNumberForTocKey(String tocKey) {
+        for (Map<String, Object> tocEntry : this.tocEntries) {
+            if (tocKey.equals(tocEntry.get(TOC_KEY))) {
+                return (Integer) tocEntry.get(PAGE_NUMBER);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Sets the page number for the given key.
+     * @param tocKey A key that uniquely identifies an anchor name of a report field.
+     * @param pageNumber An Integer value, holding the page number.
+     * @return
+     */
+    public String setPageNumberForTocKey(String tocKey, Integer pageNumber) {
+        tocEntries.add(createTocEntry(tocKey, pageNumber));
+        return tocKey;
+    }
+
+    private Map<String, Object> createTocEntry(String tocKey, Integer pageNumber) {
+        Map<String, Object> tocEntry = new HashMap<>();
+        tocEntry.put(TOC_KEY, tocKey);
+        tocEntry.put(PAGE_NUMBER, pageNumber);
+        return tocEntry;
+    }
+}

--- a/jasperreports/src/net/sf/jasperreports/util/TocCreator.java
+++ b/jasperreports/src/net/sf/jasperreports/util/TocCreator.java
@@ -1,6 +1,8 @@
 package net.sf.jasperreports.util;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -9,6 +11,9 @@ import java.util.Map;
  * This class is used to gather page numbers during report fill time. Each page number is associated to a String key.
  * During collection, key/page number pairs are added. When finished, the TOC data are available for direct retrieval
  * by TOC key.
+ *
+ * There are also a pair of queues that can be used if the key is unavailable, for example when loading the table of
+ * contents in a list (lists do not support evaluation time so the dataset will be run before the TOC is ready).
  */
 public class TocCreator {
 
@@ -16,6 +21,8 @@ public class TocCreator {
     private static final String PAGE_NUMBER = "pageNumber";
 
     private final List<Map<String, Object>> tocEntries = new ArrayList<>();
+    private final Deque<Integer> pageNumberDequeue = new ArrayDeque<>();
+    private final Deque<String> tocKeyDequeue = new ArrayDeque<>();
 
     /**
      * Returns the page number for the given key.
@@ -23,12 +30,32 @@ public class TocCreator {
      * @return
      */
     public Integer getPageNumberForTocKey(String tocKey) {
+
         for (Map<String, Object> tocEntry : this.tocEntries) {
             if (tocKey.equals(tocEntry.get(TOC_KEY))) {
                 return (Integer) tocEntry.get(PAGE_NUMBER);
             }
         }
+
         return null;
+    }
+
+    public Integer removeFirstPageNumber() {
+
+        if (!pageNumberDequeue.isEmpty()) {
+            return pageNumberDequeue.removeFirst();
+        }
+
+        return -1;
+    }
+
+    public String removeFirstTocKey() {
+
+        if (!tocKeyDequeue.isEmpty()) {
+            return tocKeyDequeue.removeFirst();
+        }
+
+        return "<Error: tocKeyDequeue is empty>";
     }
 
     /**
@@ -38,14 +65,20 @@ public class TocCreator {
      * @return
      */
     public String setPageNumberForTocKey(String tocKey, Integer pageNumber) {
+
         tocEntries.add(createTocEntry(tocKey, pageNumber));
+        tocKeyDequeue.add(tocKey);
+        pageNumberDequeue.add(pageNumber);
+
         return tocKey;
     }
 
     private Map<String, Object> createTocEntry(String tocKey, Integer pageNumber) {
+
         Map<String, Object> tocEntry = new HashMap<>();
         tocEntry.put(TOC_KEY, tocKey);
         tocEntry.put(PAGE_NUMBER, pageNumber);
+
         return tocEntry;
     }
 }

--- a/jasperreports/src/net/sf/jasperreports/util/TocCreator.java
+++ b/jasperreports/src/net/sf/jasperreports/util/TocCreator.java
@@ -7,7 +7,8 @@ import java.util.Map;
 
 /**
  * This class is used to gather page numbers during report fill time. Each page number is associated to a String key.
- * During collection, key/page number pairs are added. When finished, the TOC data are returned as a JRDataSource.
+ * During collection, key/page number pairs are added. When finished, the TOC data are available for direct retrieval
+ * by TOC key.
  */
 public class TocCreator {
 

--- a/jasperreports/src/net/sf/jasperreports/util/Utilities.java
+++ b/jasperreports/src/net/sf/jasperreports/util/Utilities.java
@@ -1,0 +1,14 @@
+package net.sf.jasperreports.util;
+
+import java.util.Map;
+
+import net.sf.jasperreports.engine.JRDefaultScriptlet;
+
+public class Utilities extends JRDefaultScriptlet {
+
+    public boolean getRequiredStringBooleanMapValue(Map<String, Boolean> map, String mapKey) {
+        return map.computeIfAbsent(mapKey, s -> {
+            throw new RuntimeException("Missing entry in map for required key: \"" + mapKey + "\"");
+        });
+    }
+}

--- a/jasperreports/src/net/sf/jasperreports/util/Utilities.java
+++ b/jasperreports/src/net/sf/jasperreports/util/Utilities.java
@@ -3,6 +3,7 @@ package net.sf.jasperreports.util;
 import java.util.Map;
 
 import net.sf.jasperreports.engine.JRDefaultScriptlet;
+import net.sf.jasperreports.renderers.SimpleRenderToImageAwareDataRenderer;
 
 public class Utilities extends JRDefaultScriptlet {
 
@@ -22,6 +23,10 @@ public class Utilities extends JRDefaultScriptlet {
         return map.computeIfAbsent(mapKey, s -> {
             throw missingKeyException(mapKey);
         });
+    }
+
+    public SimpleRenderToImageAwareDataRenderer createImageExpressionFromSvg(String svg) {
+        return SimpleRenderToImageAwareDataRenderer.getInstance(svg.getBytes());
     }
 
     private RuntimeException missingKeyException(String key) {

--- a/jasperreports/src/net/sf/jasperreports/util/Utilities.java
+++ b/jasperreports/src/net/sf/jasperreports/util/Utilities.java
@@ -8,7 +8,17 @@ public class Utilities extends JRDefaultScriptlet {
 
     public boolean getRequiredStringBooleanMapValue(Map<String, Boolean> map, String mapKey) {
         return map.computeIfAbsent(mapKey, s -> {
-            throw new RuntimeException("Missing entry in map for required key: \"" + mapKey + "\"");
+            throw missingKeyException(mapKey);
         });
+    }
+
+    public String getRequiredStringStringMapValue(Map<String, String> map, String mapKey) {
+        return map.computeIfAbsent(mapKey, s -> {
+            throw missingKeyException(mapKey);
+        });
+    }
+
+    private RuntimeException missingKeyException(String key) {
+        return new RuntimeException("Missing entry in map for required key: \"" + key + "\"");
     }
 }

--- a/jasperreports/src/net/sf/jasperreports/util/Utilities.java
+++ b/jasperreports/src/net/sf/jasperreports/util/Utilities.java
@@ -18,6 +18,12 @@ public class Utilities extends JRDefaultScriptlet {
         });
     }
 
+    public int getRequiredStringIntegerMapValue(Map<String, Integer> map, String mapKey) {
+        return map.computeIfAbsent(mapKey, s -> {
+            throw missingKeyException(mapKey);
+        });
+    }
+
     private RuntimeException missingKeyException(String key) {
         return new RuntimeException("Missing entry in map for required key: \"" + key + "\"");
     }

--- a/jasperreports/tests/net/sf/jasperreports/components/map/PolylineEncoderTest.java
+++ b/jasperreports/tests/net/sf/jasperreports/components/map/PolylineEncoderTest.java
@@ -1,0 +1,61 @@
+package net.sf.jasperreports.components.map;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class PolylineEncoderTest {
+
+    /* Example from google:
+     * const path = [
+     *   [38.5, -120.2],
+     *   [40.7, -120.95],
+     *   [43.252, -126.453],
+     * ];
+     * console.log(encode(path, 5));
+     * // "_p~iF~ps|U_ulLnnqC_mqNvxq`@"
+     */
+    @Test
+    public void testEncodeNonPolygon() {
+
+        List<Map<String, Object>> locations = new ArrayList<>();
+        locations.add(createTestLocation(38.5, -120.2));
+        locations.add(createTestLocation(40.7, -120.95));
+        locations.add(createTestLocation(43.252, -126.453));
+
+        String enc = new PolylineEncoder(locations, false).encode();
+
+        final String expected = "_p~iF~ps|U_ulLnnqC_mqNvxq`@";
+
+        assertEquals(expected, enc);
+    }
+
+    @Test
+    public void testEncodePolygon() {
+
+        List<Map<String, Object>> locations = new ArrayList<>();
+        locations.add(createTestLocation(38.5, -120.2));
+        locations.add(createTestLocation(40.7, -120.95));
+        locations.add(createTestLocation(43.252, -126.453));
+
+        String enc = new PolylineEncoder(locations, true).encode();
+
+        final String expected = "_p~iF~ps|U_ulLnnqC_mqNvxq`@~b_\\ghde@";
+
+        assertEquals(expected, enc);
+    }
+
+    private static Map<String, Object> createTestLocation(double lat, double lng) {
+        Map<String, Object> location = new HashMap<>();
+
+        location.put(MapComponent.ITEM_PROPERTY_latitude, lat);
+        location.put(MapComponent.ITEM_PROPERTY_longitude, lng);
+
+        return location;
+    }
+}


### PR DESCRIPTION
Only append reference text if the current text doesn't already contain the reference text. This is to avoid duplicate entries in references where an element has been processed twice after the rendering engine determines that a split-type "Prevent" detail must be shifted to a new page to prevent detail split.