### PR TITLE
upgrading net.tascalate.javaflow.tools.maven.version from 2.7.5 to 2.…

### DIFF
--- a/pom-parent.xml
+++ b/pom-parent.xml
@@ -106,7 +106,7 @@
 		<maven-surefire-plugin.version>3.2.3</maven-surefire-plugin.version>
 		<clirr-maven-plugin.version>2.8</clirr-maven-plugin.version>
 		<maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-		<net.tascalate.javaflow.tools.maven.version>2.7.5</net.tascalate.javaflow.tools.maven.version>
+		<net.tascalate.javaflow.tools.maven.version>2.7.6</net.tascalate.javaflow.tools.maven.version>
 		<maven-replacer-plugin.version>1.5.3</maven-replacer-plugin.version>
 		<xml-maven-plugin.version>1.1.0</xml-maven-plugin.version>
 		<maven-markdown-page-generator-plugin.version>2.4.0</maven-markdown-page-generator-plugin.version>


### PR DESCRIPTION
…7.6 version (found reference on https://mvnrepository.com/artifact/net.tascalate.javaflow/net.tascalate.javaflow.tools.maven) to ensure compilation against OpenJDK 22 (tested with 22.0.1)