### PR TITLE
OpenLibre renamed getRadioField to getKidField

### DIFF
--- a/ext/pdf/src/main/java/net/sf/jasperreports/pdf/classic/ClassicRadioCheck.java
+++ b/ext/pdf/src/main/java/net/sf/jasperreports/pdf/classic/ClassicRadioCheck.java
@@ -91,7 +91,7 @@ public class ClassicRadioCheck extends ClassicPdfField implements PdfRadioCheck
 		PdfFormField radioGroup = pdfProducer.getRadioGroup(radioCheckField);
 		try
 		{
-			radioGroup.addKid(radioCheckField.getRadioField());
+			radioGroup.addKid(radioCheckField.getKidField());
 		}
 		catch (DocumentException e)
 		{


### PR DESCRIPTION
This makes it compatible with future releases of OpenLibre like 1.4 and 2.x eventually.

This is supported in 1.3 the version you are using and getRadioField is marked deprecated.

For my GraalVM support I had to override this see here: https://github.com/quarkiverse/quarkus-jasperreports/blob/main/runtime/src/main/java/net/sf/jasperreports/pdf/classic/ClassicRadioCheckSubstitution.java